### PR TITLE
CI/release: full CI gate on tag push, add staticcheck + gosec, pre-flight goreleaser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Reusable — release.yml calls this workflow as a quality gate before
+  # GoReleaser runs, so a failing lint/test/vuln check blocks a release
+  # at the tagged SHA instead of producing a half-published state.
+  workflow_call:
 
 permissions:
   contents: read
@@ -48,12 +52,29 @@ jobs:
       - name: go vet
         run: go vet ./...
 
+      - name: staticcheck
+        run: |
+          go install honnef.co/go/tools/cmd/staticcheck@latest
+          staticcheck ./...
+
+      - name: gosec
+        # Exclusions mirror `task lint` in Taskfile.yml; each code is
+        # justified there. Keep the two lists in sync when editing.
+        run: |
+          go install github.com/securego/gosec/v2/cmd/gosec@latest
+          gosec -quiet -exclude-dir=testdata \
+            -exclude=G104,G115,G301,G302,G306,G304,G401,G501,G505,G204,G704 \
+            ./...
+
       - name: govulncheck
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
 
       - name: Test
+        # -race runs the full suite; seed-corpus fuzz targets replay as
+        # regular tests inside this call, so `task fuzz` is covered
+        # implicitly. Heavy `task fuzz-deep` stays local/manual.
         run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,18 @@ permissions:
   pull-requests: write  # Belt-and-braces; auto-merge step uses HOMEBREW_TAP_GITHUB_TOKEN
 
 jobs:
+  # Quality gate: re-runs the full CI job (lint + staticcheck + gosec +
+  # govulncheck + race-enabled test matrix + build) on the tagged SHA.
+  # If anything fails here, goreleaser never starts — no half-published
+  # state to clean up. The duplicate work vs. the ci.yml run on main is
+  # cheap insurance against drift between the main-push and the tag.
+  ci:
+    name: CI gate
+    uses: ./.github/workflows/ci.yml
+
   goreleaser:
     name: GoReleaser
+    needs: ci
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,6 +35,24 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:
           experimental: true
+
+      # Pre-flight: catch a broken .goreleaser.yaml before the full
+      # cross-compile burns ~3 minutes and before we touch the GitHub
+      # Release API. Cheap (<1s) so always worth running.
+      - name: goreleaser check
+        run: mise exec -- goreleaser check
+
+      # Snapshot dry-run: exercises the full cross-compile matrix, SBOM
+      # generation, archive creation, and cask template rendering
+      # without publishing or signing. Surfaces platform-specific
+      # build breakage (e.g. a stdlib API that compiles on the
+      # developer's host but not on darwin/arm64) before the real
+      # release step tries to upload.
+      - name: goreleaser release --snapshot (dry run)
+        run: |
+          mise exec -- goreleaser release --snapshot --clean
+          # Discard snapshot artifacts — the real release below starts fresh.
+          rm -rf dist/
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7


### PR DESCRIPTION
## Summary

- `ci.yml` becomes a reusable workflow (`workflow_call`) and gains `staticcheck` + `gosec` steps with exclusions mirroring `task lint` in `Taskfile.yml`.
- `release.yml` splits into two jobs: a `ci` gate that calls `ci.yml` + a `goreleaser` job that `needs: ci`. If the tagged SHA fails CI, GoReleaser never starts — no half-published state.
- Adds two pre-flight steps before the real GoReleaser run: `goreleaser check` (validates `.goreleaser.yaml`) and `goreleaser release --snapshot --clean` (full cross-compile dry run, SBOM + cask template rendering, no network).

## Why

Today `release.yml` runs no tests, no lints, no vuln check — it trusts that `main` was CI-green before the tag was pushed. Tag pushes don't re-trigger `ci.yml`, so a post-CI drift in `main` (unlikely but possible) or a stale `.goreleaser.yaml` would only fail mid-publish, after cosign signing and partial uploads. This change moves the quality gate to the tag SHA itself.

## Tradeoffs

- Tag-push → published release goes from ~4 min → ~7–9 min (CI gate 3–5 min + snapshot ~1 min).
- `staticcheck` / `gosec` are pulled via `go install ...@latest` in CI — matches the existing `govulncheck` pattern. A toolchain update could flag previously-clean code; pin via mise if that becomes a problem.
- CI gate duplicates work when `main`-push already ran CI on the same SHA. Intentional: re-running on the tag SHA protects against any drift between the two events.

## Deliberately out of scope

- Windows in the CI matrix (separate change).
- Branch protection on `main` requiring CI green (GitHub repo settings, not a file change; flagged as Step 5 in the original plan).
- Pinning `staticcheck` / `gosec` via `.tool-versions` (worth doing, but orthogonal).

## Test plan

- [ ] CI on this PR passes with the new `staticcheck` + `gosec` steps (validates the extra lints don't flag anything on current main).
- [ ] Next release (when cut) exercises the new `ci` gate + pre-flight snapshot path end-to-end; confirm the tap PR still merges and the GitHub Release still lands.
- [ ] If snapshot step proves noisy or slow without value, drop it while keeping `goreleaser check` (cheap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)