### PR TITLE
Add copyright/SPDX headers to all non-Go source files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,3 +1,6 @@
+# Copyright (c) 2021-2026 Truestamp, Inc.
+# SPDX-License-Identifier: MIT
+
 name: Bug Report
 description: Report a problem with the Truestamp CLI
 labels: [bug]

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,3 +1,6 @@
+# Copyright (c) 2021-2026 Truestamp, Inc.
+# SPDX-License-Identifier: MIT
+
 name: Feature Request
 description: Suggest an idea for the Truestamp CLI
 labels: [enhancement]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,6 @@
+# Copyright (c) 2021-2026 Truestamp, Inc.
+# SPDX-License-Identifier: MIT
+
 version: 2
 
 updates:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+# Copyright (c) 2021-2026 Truestamp, Inc.
+# SPDX-License-Identifier: MIT
+
 name: CI
 
 on:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,3 +1,6 @@
+# Copyright (c) 2021-2026 Truestamp, Inc.
+# SPDX-License-Identifier: MIT
+
 name: CodeQL
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,6 @@
+# Copyright (c) 2021-2026 Truestamp, Inc.
+# SPDX-License-Identifier: MIT
+
 name: Release
 
 on:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2021-2026 Truestamp, Inc.
+# SPDX-License-Identifier: MIT
+#
 # GoReleaser configuration for truestamp-cli.
 # Reference: https://goreleaser.com/customization/
 #

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,3 +1,6 @@
+# Copyright (c) 2021-2026 Truestamp, Inc.
+# SPDX-License-Identifier: MIT
+#
 # https://taskfile.dev
 
 version: "3"

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Copyright (c) 2021-2026 Truestamp, Inc.
+# SPDX-License-Identifier: MIT
+#
 # Truestamp CLI installer.
 #
 # Source:  https://github.com/truestamp/truestamp-cli/blob/main/docs/install.sh

--- a/docs/install.test.sh
+++ b/docs/install.test.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Copyright (c) 2021-2026 Truestamp, Inc.
+# SPDX-License-Identifier: MIT
+#
 # End-to-end smoke test for docs/install.sh.
 #
 # Runs the installer against a real, pinned GitHub release into a disposable

--- a/internal/config/defaults/config.toml
+++ b/internal/config/defaults/config.toml
@@ -1,3 +1,6 @@
+# Copyright (c) 2021-2026 Truestamp, Inc.
+# SPDX-License-Identifier: MIT
+#
 # Truestamp CLI Configuration
 #
 # Location:


### PR DESCRIPTION
## Summary

Every `.go` file already carried the canonical two-line Truestamp header. 11 non-Go source files did not. This adds them everywhere for consistent SBOM / license-scanner output.

## Files touched

YAML / TOML (header as `#` comments at top, before any content):

- `.github/workflows/ci.yml`
- `.github/workflows/codeql.yml`
- `.github/workflows/release.yml`
- `.github/ISSUE_TEMPLATE/bug_report.yml`
- `.github/ISSUE_TEMPLATE/feature_request.yml`
- `.github/dependabot.yml`
- `.goreleaser.yaml`
- `Taskfile.yml`
- `internal/config/defaults/config.toml`

Shell (header placed **after** the shebang so `sh` execution still works):

- `docs/install.sh`
- `docs/install.test.sh`

## Notes

- `internal/config/defaults/config.toml` is embedded into the binary via `go:embed` and written to user machines by `truestamp config init`. The header is now visible in freshly-generated configs. Confirmed rendered output matches expectations.
- No code changes; CI and tests unaffected.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./internal/config/...` green (the only package that reads the TOML).
- [x] Generated user config includes the header correctly (spot-checked via `config init` into a temp dir).
- [ ] CI matrix on this PR passes (validates staticcheck / gosec / test on all platforms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)