### PR TITLE
Docs: roll copyright year to 2019, refresh bug-report template, fix stale flag examples

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2026 Truestamp, Inc.
+# Copyright (c) 2019-2026 Truestamp, Inc.
 # SPDX-License-Identifier: MIT
 
 name: Bug Report
@@ -8,8 +8,12 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to file a report. Please include the output of
-        `truestamp version` and the exact command you ran.
+        Thanks for taking the time to file a report.
+
+        **Before you submit:**
+        - Paste the full output of `truestamp version` — it includes the detected install method, OS/arch, Go version, and build date.
+        - If the bug involves a specific proof, item, block, beacon, or entropy record, include its ID (ULID or UUIDv7). Maintainers can correlate IDs with server-side logs.
+        - **Do not paste API keys, private keys, or claims data you consider sensitive.** `truestamp config show` masks the API key for you.
 
   - type: textarea
     id: version
@@ -17,22 +21,62 @@ body:
       label: Version output
       description: Paste the full output of `truestamp version`.
       render: shell
+      placeholder: |
+        $ truestamp version
+        truestamp
+          version      v0.7.0
+          path         github.com/truestamp/truestamp-cli
+          config path  /Users/you/.config/truestamp/config.toml
+          install      homebrew
+          go           go1.26.2 for darwin/arm64
+          commit       648e610
+          built        2026-04-23T18:09:15Z
+    validations:
+      required: true
+
+  - type: dropdown
+    id: subcommand
+    attributes:
+      label: Affected subcommand
+      description: Which `truestamp` sub-command produced the bug?
+      options:
+        - verify
+        - create
+        - download
+        - beacon
+        - hash
+        - encode / decode / jcs
+        - convert
+        - config
+        - auth
+        - upgrade
+        - version
+        - Other / unclear
     validations:
       required: true
 
   - type: textarea
     id: command
     attributes:
-      label: Command
-      description: The exact command invocation that triggered the issue.
+      label: Exact command
+      description: The exact `truestamp …` invocation that triggered the issue. Redact anything sensitive (API key, file paths under $HOME with your real username, etc.).
       render: shell
+      placeholder: truestamp verify --url https://example.com/proof.json
     validations:
       required: true
+
+  - type: input
+    id: subject-id
+    attributes:
+      label: Subject ID (if applicable)
+      description: The ULID (items) or UUIDv7 (blocks, beacons, entropy) involved in the bug, if the command was tied to a specific record. Helps correlate with server logs.
+      placeholder: "01KNN33GX5E470CB9TRWAYF9DD  or  019d6a32-13e6-72b0-97e5-3779231ea97b"
 
   - type: textarea
     id: expected
     attributes:
       label: Expected behavior
+      description: What did you expect the command to do?
     validations:
       required: true
 
@@ -40,17 +84,50 @@ body:
     id: actual
     attributes:
       label: Actual behavior
-      description: Include the full output. Use `--output debug` for verbose detail.
+      description: |
+        What actually happened? Include the full terminal output (or the exit code if there was no output). For structured output that's easier to inspect, re-run the command with `--json` if the sub-command supports it. For non-obvious failures, include any stderr lines verbatim.
       render: shell
     validations:
       required: true
 
-  - type: input
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps for someone else to trigger the same bug. Include any input files or URLs if safe to share.
+      placeholder: |
+        1. Run `truestamp download --type item 01K…`
+        2. Pipe to `truestamp verify`
+        3. Observe exit code 1 with message "…"
+
+  - type: dropdown
     id: install-method
     attributes:
       label: Install method
-      description: brew / go install / direct download / task build
-      placeholder: "brew install truestamp/tap/truestamp-cli"
+      description: How did you install this copy of `truestamp`? `truestamp version` reports this on the `install` line.
+      options:
+        - Homebrew (`brew install truestamp/tap/truestamp-cli`)
+        - install.sh (`curl -fsSL https://get.truestamp.com/install.sh | sh`)
+        - Direct tarball download from GitHub Releases
+        - "`go install github.com/truestamp/truestamp-cli/cmd/truestamp@latest`"
+        - Built locally from source (`task build`)
+        - Other / unsure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      description: Run `uname -sm` (macOS/Linux) or `systeminfo | findstr /B /C:"OS"` (Windows) if unsure.
+      options:
+        - macOS (arm64 / Apple Silicon)
+        - macOS (amd64 / Intel)
+        - Linux (amd64)
+        - Linux (arm64)
+        - Windows (amd64)
+        - Windows (arm64)
+        - Other
     validations:
       required: true
 
@@ -58,4 +135,5 @@ body:
     id: additional
     attributes:
       label: Additional context
-      description: Proof file characteristics, network environment, relevant config.
+      description: |
+        Anything else that might help — network environment (corporate proxy, restrictive firewall), relevant config (`truestamp config show` with any sensitive values redacted), proof bundle characteristics, whether the issue is reproducible or intermittent, screenshots, etc.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2026 Truestamp, Inc.
+# Copyright (c) 2019-2026 Truestamp, Inc.
 # SPDX-License-Identifier: MIT
 
 name: Feature Request

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2026 Truestamp, Inc.
+# Copyright (c) 2019-2026 Truestamp, Inc.
 # SPDX-License-Identifier: MIT
 
 version: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2026 Truestamp, Inc.
+# Copyright (c) 2019-2026 Truestamp, Inc.
 # SPDX-License-Identifier: MIT
 
 name: CI

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2026 Truestamp, Inc.
+# Copyright (c) 2019-2026 Truestamp, Inc.
 # SPDX-License-Identifier: MIT
 
 name: CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2026 Truestamp, Inc.
+# Copyright (c) 2019-2026 Truestamp, Inc.
 # SPDX-License-Identifier: MIT
 
 name: Release

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2026 Truestamp, Inc.
+# Copyright (c) 2019-2026 Truestamp, Inc.
 # SPDX-License-Identifier: MIT
 #
 # GoReleaser configuration for truestamp-cli.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -735,7 +735,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Terminal-themed landing page at `https://get.truestamp.com` with plain
   green-on-black monospace install instructions.
 - `shellcheck` step in CI to keep `docs/install.sh` portable POSIX sh.
-- SPDX-style `Copyright (c) 2021-2026 Truestamp, Inc.` +
+- SPDX-style `Copyright (c) 2019-2026 Truestamp, Inc.` +
   `SPDX-License-Identifier: MIT` header on all 48 Go source files under
   `cmd/` and `internal/`.
 - Copyright footer in `README.md` and the `get.truestamp.com` landing

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ truestamp verify proof.json --skip-external
 Silent mode for scripting:
 
 ```sh
-truestamp verify proof.json --output silent && echo valid || echo invalid
+truestamp verify proof.json --silent && echo valid || echo invalid
 ```
 
 Other input sources:
@@ -361,4 +361,4 @@ Dev setup, testing, and release process are in [`CONTRIBUTING.md`](./CONTRIBUTIN
 
 MIT. See [LICENSE](./LICENSE).
 
-Copyright (c) 2021-2026 [Truestamp, Inc.](https://truestamp.com) All rights reserved.
+Copyright (c) 2019-2026 [Truestamp, Inc.](https://truestamp.com) All rights reserved.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2026 Truestamp, Inc.
+# Copyright (c) 2019-2026 Truestamp, Inc.
 # SPDX-License-Identifier: MIT
 #
 # https://taskfile.dev
@@ -74,7 +74,7 @@ tasks:
   # =============================================================================
 
   run:
-    desc: "Run verify without building (usage: task run -- proof.json [--verbose] [--skip-external])"
+    desc: "Run verify without building (usage: task run -- proof.json [--skip-external] [--skip-signatures] [--json])"
     cmds:
       - go run ./cmd/truestamp verify {{.CLI_ARGS}}
 

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/beacon.go
+++ b/cmd/beacon.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/beacon_by_hash.go
+++ b/cmd/beacon_by_hash.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/beacon_get.go
+++ b/cmd/beacon_get.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/beacon_list.go
+++ b/cmd/beacon_list.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/beacon_test.go
+++ b/cmd/beacon_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/codec.go
+++ b/cmd/codec.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/codec_test.go
+++ b/cmd/codec_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/convert_id.go
+++ b/cmd/convert_id.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/convert_keyid.go
+++ b/cmd/convert_keyid.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/convert_merkle.go
+++ b/cmd/convert_merkle.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/convert_proof.go
+++ b/cmd/convert_proof.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/convert_test.go
+++ b/cmd/convert_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/convert_time.go
+++ b/cmd/convert_time.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/coverage_extra_test.go
+++ b/cmd/coverage_extra_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/fuzz_test.go
+++ b/cmd/fuzz_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/golden_test.go
+++ b/cmd/golden_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/hash.go
+++ b/cmd/hash.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/hash_test.go
+++ b/cmd/hash_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 // Package cmd wires up the cobra command tree for the Truestamp CLI. The

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/timestamp_test.go
+++ b/cmd/timestamp_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/truestamp/main.go
+++ b/cmd/truestamp/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package main

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/verify_test.go
+++ b/cmd/verify_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package cmd

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (c) 2021-2026 Truestamp, Inc.
+# Copyright (c) 2019-2026 Truestamp, Inc.
 # SPDX-License-Identifier: MIT
 #
 # Truestamp CLI installer.

--- a/docs/install.test.sh
+++ b/docs/install.test.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (c) 2021-2026 Truestamp, Inc.
+# Copyright (c) 2019-2026 Truestamp, Inc.
 # SPDX-License-Identifier: MIT
 #
 # End-to-end smoke test for docs/install.sh.

--- a/internal/beacons/client.go
+++ b/internal/beacons/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 // Package beacons is a thin client for the Truestamp Beacons JSON:API

--- a/internal/beacons/client_test.go
+++ b/internal/beacons/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package beacons

--- a/internal/beacons/fuzz_test.go
+++ b/internal/beacons/fuzz_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package beacons

--- a/internal/bitcoin/fuzz_test.go
+++ b/internal/bitcoin/fuzz_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package bitcoin

--- a/internal/bitcoin/merkle.go
+++ b/internal/bitcoin/merkle.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 // Package bitcoin provides BIP 37 partial merkle tree verification

--- a/internal/bitcoin/merkle_test.go
+++ b/internal/bitcoin/merkle_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package bitcoin

--- a/internal/bitcoin/parse.go
+++ b/internal/bitcoin/parse.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package bitcoin

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 // Package config resolves the CLI's runtime configuration from compiled

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package config

--- a/internal/config/config_unix.go
+++ b/internal/config/config_unix.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 //go:build !windows

--- a/internal/config/config_windows.go
+++ b/internal/config/config_windows.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 //go:build windows

--- a/internal/config/defaults/config.toml
+++ b/internal/config/defaults/config.toml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2026 Truestamp, Inc.
+# Copyright (c) 2019-2026 Truestamp, Inc.
 # SPDX-License-Identifier: MIT
 #
 # Truestamp CLI Configuration

--- a/internal/config/fuzz_test.go
+++ b/internal/config/fuzz_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package config

--- a/internal/config/persist.go
+++ b/internal/config/persist.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package config

--- a/internal/config/persist_test.go
+++ b/internal/config/persist_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package config

--- a/internal/encoding/bench_test.go
+++ b/internal/encoding/bench_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package encoding

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 // Package encoding is a small translation layer over the stdlib

--- a/internal/encoding/encoding_test.go
+++ b/internal/encoding/encoding_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package encoding

--- a/internal/encoding/fuzz_test.go
+++ b/internal/encoding/fuzz_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package encoding

--- a/internal/external/bitcoin.go
+++ b/internal/external/bitcoin.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 // Package external fetches supplementary data from public blockchains (Stellar

--- a/internal/external/external_test.go
+++ b/internal/external/external_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package external

--- a/internal/external/fuzz_test.go
+++ b/internal/external/fuzz_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package external

--- a/internal/external/keyring.go
+++ b/internal/external/keyring.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package external

--- a/internal/external/nist.go
+++ b/internal/external/nist.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package external

--- a/internal/external/stellar.go
+++ b/internal/external/stellar.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package external

--- a/internal/hashing/bench_test.go
+++ b/internal/hashing/bench_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package hashing

--- a/internal/hashing/fuzz_test.go
+++ b/internal/hashing/fuzz_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package hashing

--- a/internal/hashing/hashing.go
+++ b/internal/hashing/hashing.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 // Package hashing exposes the full set of cryptographic hash algorithms

--- a/internal/hashing/hashing_test.go
+++ b/internal/hashing/hashing_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package hashing

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 // Package httpclient provides a shared HTTP client for all external API calls.

--- a/internal/httpclient/client_test.go
+++ b/internal/httpclient/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package httpclient

--- a/internal/httpclient/download.go
+++ b/internal/httpclient/download.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package httpclient

--- a/internal/httpclient/download_test.go
+++ b/internal/httpclient/download_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package httpclient

--- a/internal/inputsrc/fuzz_test.go
+++ b/internal/inputsrc/fuzz_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package inputsrc

--- a/internal/inputsrc/inputsrc.go
+++ b/internal/inputsrc/inputsrc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 // Package inputsrc resolves a CLI input to a byte slice (or a stream) from

--- a/internal/inputsrc/inputsrc_test.go
+++ b/internal/inputsrc/inputsrc_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package inputsrc

--- a/internal/install/detect.go
+++ b/internal/install/detect.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 // Package install detects how the running truestamp binary was installed.

--- a/internal/install/detect_test.go
+++ b/internal/install/detect_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package install

--- a/internal/items/create.go
+++ b/internal/items/create.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 // Package items provides API operations for Truestamp items.

--- a/internal/items/create_test.go
+++ b/internal/items/create_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package items

--- a/internal/items/fuzz_test.go
+++ b/internal/items/fuzz_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package items

--- a/internal/proof/bench_test.go
+++ b/internal/proof/bench_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package proof

--- a/internal/proof/binary.go
+++ b/internal/proof/binary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 // Package proof parses, downloads, and generates Truestamp proof bundles in

--- a/internal/proof/download.go
+++ b/internal/proof/download.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package proof

--- a/internal/proof/download_test.go
+++ b/internal/proof/download_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package proof

--- a/internal/proof/extra_test.go
+++ b/internal/proof/extra_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package proof

--- a/internal/proof/fuzz_test.go
+++ b/internal/proof/fuzz_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package proof

--- a/internal/proof/id.go
+++ b/internal/proof/id.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package proof

--- a/internal/proof/marshal_cbor.go
+++ b/internal/proof/marshal_cbor.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package proof

--- a/internal/proof/marshal_cbor_test.go
+++ b/internal/proof/marshal_cbor_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package proof

--- a/internal/proof/parse.go
+++ b/internal/proof/parse.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package proof

--- a/internal/proof/parse_test.go
+++ b/internal/proof/parse_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package proof

--- a/internal/proof/ptype/ptype.go
+++ b/internal/proof/ptype/ptype.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 // Package ptype holds the frozen registry of proof type integer codes used

--- a/internal/proof/ptype/ptype_test.go
+++ b/internal/proof/ptype/ptype_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package ptype

--- a/internal/proof/types.go
+++ b/internal/proof/types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package proof

--- a/internal/selfupgrade/check_test.go
+++ b/internal/selfupgrade/check_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package selfupgrade

--- a/internal/selfupgrade/extract.go
+++ b/internal/selfupgrade/extract.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package selfupgrade

--- a/internal/selfupgrade/extract_test.go
+++ b/internal/selfupgrade/extract_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package selfupgrade

--- a/internal/selfupgrade/fuzz_test.go
+++ b/internal/selfupgrade/fuzz_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package selfupgrade

--- a/internal/selfupgrade/github.go
+++ b/internal/selfupgrade/github.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package selfupgrade

--- a/internal/selfupgrade/misc_test.go
+++ b/internal/selfupgrade/misc_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package selfupgrade

--- a/internal/selfupgrade/replace_test.go
+++ b/internal/selfupgrade/replace_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 //go:build !windows

--- a/internal/selfupgrade/replace_unix.go
+++ b/internal/selfupgrade/replace_unix.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 //go:build !windows

--- a/internal/selfupgrade/replace_windows.go
+++ b/internal/selfupgrade/replace_windows.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 //go:build windows

--- a/internal/selfupgrade/selfupgrade.go
+++ b/internal/selfupgrade/selfupgrade.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 // Package selfupgrade implements the in-place upgrade flow for users who

--- a/internal/selfupgrade/semver.go
+++ b/internal/selfupgrade/semver.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package selfupgrade

--- a/internal/selfupgrade/semver_test.go
+++ b/internal/selfupgrade/semver_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package selfupgrade

--- a/internal/selfupgrade/verify.go
+++ b/internal/selfupgrade/verify.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package selfupgrade

--- a/internal/selfupgrade/verify_test.go
+++ b/internal/selfupgrade/verify_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package selfupgrade

--- a/internal/tscrypto/bench_test.go
+++ b/internal/tscrypto/bench_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package tscrypto

--- a/internal/tscrypto/fuzz_test.go
+++ b/internal/tscrypto/fuzz_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package tscrypto

--- a/internal/tscrypto/hash.go
+++ b/internal/tscrypto/hash.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 // Package tscrypto implements the Truestamp-specific cryptographic

--- a/internal/tscrypto/hash_test.go
+++ b/internal/tscrypto/hash_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package tscrypto

--- a/internal/tscrypto/merkle.go
+++ b/internal/tscrypto/merkle.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package tscrypto

--- a/internal/tscrypto/merkle_test.go
+++ b/internal/tscrypto/merkle_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package tscrypto

--- a/internal/tscrypto/signature.go
+++ b/internal/tscrypto/signature.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package tscrypto

--- a/internal/tscrypto/signature_test.go
+++ b/internal/tscrypto/signature_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package tscrypto

--- a/internal/tscrypto/ulid.go
+++ b/internal/tscrypto/ulid.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package tscrypto

--- a/internal/tscrypto/ulid_test.go
+++ b/internal/tscrypto/ulid_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package tscrypto

--- a/internal/tscrypto/uuidv7.go
+++ b/internal/tscrypto/uuidv7.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package tscrypto

--- a/internal/tscrypto/uuidv7_test.go
+++ b/internal/tscrypto/uuidv7_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package tscrypto

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 // Package ui provides shared styling for the Truestamp CLI using lipgloss v2.

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package ui

--- a/internal/ui/weburls.go
+++ b/internal/ui/weburls.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package ui

--- a/internal/ui/weburls_test.go
+++ b/internal/ui/weburls_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package ui

--- a/internal/ui/widgets.go
+++ b/internal/ui/widgets.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package ui

--- a/internal/upgradecheck/cache.go
+++ b/internal/upgradecheck/cache.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 // Package upgradecheck handles passive "new version available" notices

--- a/internal/upgradecheck/cache_unix.go
+++ b/internal/upgradecheck/cache_unix.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 //go:build !windows

--- a/internal/upgradecheck/cache_windows.go
+++ b/internal/upgradecheck/cache_windows.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 //go:build windows

--- a/internal/upgradecheck/fuzz_test.go
+++ b/internal/upgradecheck/fuzz_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package upgradecheck

--- a/internal/upgradecheck/upgradecheck.go
+++ b/internal/upgradecheck/upgradecheck.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package upgradecheck

--- a/internal/upgradecheck/upgradecheck_test.go
+++ b/internal/upgradecheck/upgradecheck_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package upgradecheck

--- a/internal/verify/fuzz_test.go
+++ b/internal/verify/fuzz_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package verify

--- a/internal/verify/helper_test.go
+++ b/internal/verify/helper_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package verify

--- a/internal/verify/json_output.go
+++ b/internal/verify/json_output.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package verify

--- a/internal/verify/presenter.go
+++ b/internal/verify/presenter.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package verify

--- a/internal/verify/remote.go
+++ b/internal/verify/remote.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package verify

--- a/internal/verify/remote_test.go
+++ b/internal/verify/remote_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package verify

--- a/internal/verify/report.go
+++ b/internal/verify/report.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package verify

--- a/internal/verify/report_test.go
+++ b/internal/verify/report_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package verify

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 // Package verify runs the end-to-end cryptographic verification pipeline

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package verify

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 // Package version provides build-time version information.

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2026 Truestamp, Inc.
+// Copyright (c) 2019-2026 Truestamp, Inc.
 // SPDX-License-Identifier: MIT
 
 package version


### PR DESCRIPTION
## Summary

Three orthogonal doc-hygiene cleanups bundled into one PR (all low-risk text changes):

**1. Copyright year:** `Copyright (c) 2021-2026` → `Copyright (c) 2019-2026` across every source file that carries the header (151 files). 2019 is the founding year; 2021 was stale.

**2. Bug-report issue template overhaul:**

- Fixed stale `--output debug` reference (flag doesn't exist; now mentions `--json` which does).
- Install methods: free-form input → dropdown with 6 supported paths (Homebrew, install.sh, direct tarball, go install, local build, other).
- Subcommand: new dropdown so triage is one click instead of reading the command.
- OS/arch: new dropdown (macOS arm64/amd64, Linux amd64/arm64, Windows amd64/arm64).
- **New Subject ID field** (optional) for the ULID / UUIDv7 of the affected item, block, beacon, or entropy record — helps maintainers correlate bugs with server logs.
- New "Steps to reproduce" textarea.
- Version field placeholder shows the full canonical `truestamp version` output.
- Opening markdown block names sensitive data categories (API keys, private keys, claims) and points at `truestamp config show` for a pre-masked snapshot.

**3. Stale flag references:**

- `README.md:168`: `--output silent` → `--silent` (the real flag).
- `Taskfile.yml:77`: `task run` description's `[--verbose]` example replaced with `[--skip-external] [--skip-signatures] [--json]`, all of which verify actually accepts.

## No code changes

Verified locally with `go build ./...` and `go test ./...` clean. Bug-report YAML parsed with `ruby -ryaml`. CI on this branch will re-validate across the matrix.

## Test plan

- [ ] CI matrix passes (ubuntu + macos with fmt + vet + staticcheck + gosec + govulncheck + race tests + build).
- [ ] shellcheck on `docs/install.sh` and `docs/install.test.sh` stays clean (year-line change is the only shell edit).
- [ ] Visual inspection of the bug-report form on GitHub after merge (the YAML renders into a web form; hard to preview locally without pushing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)