### PR TITLE
Fix self-upgrade backup vanishing for binaries older than 7 days

### DIFF
--- a/internal/selfupgrade/replace_test.go
+++ b/internal/selfupgrade/replace_test.go
@@ -71,6 +71,54 @@ func TestReplace_WithExistingBinary_CreatesBackup(t *testing.T) {
 	}
 }
 
+// TestReplace_BackupSurvivesAgedPriorBinary guards against a regression
+// where a backup of a binary installed weeks ago vanished within the same
+// Replace() call: os.Rename inherits the source's mtime, so the backup
+// arrived already past pruneOldBackups' 7-day cutoff and was reaped
+// before Replace returned. The fix calls os.Chtimes on the backup so its
+// mtime reflects the actual backup-creation time.
+func TestReplace_BackupSurvivesAgedPriorBinary(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "truestamp")
+	if err := os.WriteFile(dest, []byte("old"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Mimic a binary installed 30 days ago.
+	monthAgo := time.Now().Add(-30 * 24 * time.Hour)
+	if err := os.Chtimes(dest, monthAgo, monthAgo); err != nil {
+		t.Fatal(err)
+	}
+	newBin := filepath.Join(dir, "truestamp-new")
+	if err := os.WriteFile(newBin, []byte("new"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	backup, err := Replace(dest, newBin)
+	if err != nil {
+		t.Fatalf("Replace: %v", err)
+	}
+	if backup == "" {
+		t.Fatal("expected a backup path")
+	}
+	body, err := os.ReadFile(backup)
+	if err != nil {
+		t.Fatalf("backup file should still exist after Replace, got: %v", err)
+	}
+	if string(body) != "old" {
+		t.Errorf("backup contents: got %q, want %q", body, "old")
+	}
+	info, err := os.Stat(backup)
+	if err != nil {
+		t.Fatalf("stat backup: %v", err)
+	}
+	// Sanity-check the Chtimes touched the mtime forward: should be
+	// well within the 7-day prune window now.
+	if time.Since(info.ModTime()) > 24*time.Hour {
+		t.Errorf("backup mtime not refreshed: age=%v (expected < 24h)",
+			time.Since(info.ModTime()))
+	}
+}
+
 func TestReplace_MissingNewBin(t *testing.T) {
 	dir := t.TempDir()
 	dest := filepath.Join(dir, "truestamp")

--- a/internal/selfupgrade/replace_unix.go
+++ b/internal/selfupgrade/replace_unix.go
@@ -44,7 +44,8 @@ func Replace(destPath, newBinPath string) (backupPath string, err error) {
 	// Create backup if a prior binary exists. We keep a timestamped copy
 	// so users can manually revert if the new binary misbehaves.
 	if _, err := os.Stat(destPath); err == nil {
-		backupPath = destPath + ".bak." + time.Now().UTC().Format("20060102T150405Z")
+		now := time.Now()
+		backupPath = destPath + ".bak." + now.UTC().Format("20060102T150405Z")
 		if err := os.Rename(destPath, backupPath); err != nil {
 			// Cross-filesystem rename fails with EXDEV; fall back to copy.
 			if err := copyFile(destPath, backupPath); err != nil {
@@ -54,6 +55,13 @@ func Replace(destPath, newBinPath string) (backupPath string, err error) {
 			// the rename below will error out more usefully if this fails.
 			_ = os.Remove(destPath)
 		}
+		// Rename inherits the source file's mtime, so a backup of a
+		// binary installed weeks ago would arrive already past
+		// pruneOldBackups' 7-day cutoff and be reaped within this call.
+		// Touch the backup so its mtime reflects the actual
+		// backup-creation time. Best-effort: the safety net is mostly
+		// for manual rollback, never load-bearing.
+		_ = os.Chtimes(backupPath, now, now)
 	}
 
 	// Atomic-replace step: rename the new binary into place.


### PR DESCRIPTION
## Summary

`truestamp upgrade` silently destroyed its rollback safety net whenever the previously-installed binary was more than 7 days old (the common case for users upgrading between releases).

`Replace` in [`internal/selfupgrade/replace_unix.go`](internal/selfupgrade/replace_unix.go) creates the `.bak.<rfc3339>` backup with `os.Rename(destPath, backupPath)`. On Unix, `rename(2)` leaves the file's mtime untouched, so the backup carries the *original* binary's mtime. The same `Replace` call then ends with a best-effort `pruneOldBackups` that deletes any `*.bak.*` file with `mtime < now - 7d` — which reaps the freshly-created backup before `Replace` returns. The CLI announces the backup path on stderr while the file is already gone on disk.

## Discovered

Found while verifying the v0.8.0 release. Upgraded from an `install.sh`-installed v0.7.1 binary (built 2026-04-23, 33 days ago) to v0.8.0:

```
✓ upgraded 0.7.1 → 0.8.0
  previous binary: /Users/glenn/.local/bin/truestamp.bak.20260527T020536Z
```

…but the announced path didn't exist:

```
$ stat truestamp.bak.20260527T020536Z
stat: …: No such file or directory
```

Standalone repro (drop-in `main` package) confirmed the order: rename → inherited 30-day-old mtime → prune cutoff is 7 days → file deleted.

## Fix

One line of behaviour change: after the backup file is in place, call `os.Chtimes(backupPath, now, now)` so its mtime reflects the actual backup-creation time. The same `now` is also reused for the timestamp embedded in the filename, so they stay consistent.

## Why the existing test didn't catch it

`TestReplace_WithExistingBinary_CreatesBackup` writes the "old" destination file moments before calling `Replace`, so the destination's mtime is already near-now and the 7-day prune doesn't touch the backup. The bug only manifests when the source's mtime is older than the cutoff.

## Regression test

`TestReplace_BackupSurvivesAgedPriorBinary` mirrors the production failure shape:
1. Write old binary
2. `os.Chtimes(dest, -30 days, -30 days)` to mimic a stale install
3. `Replace(dest, newBin)`
4. Assert the backup file still exists with the old contents
5. Assert the backup's mtime was refreshed forward (within 24h of now)

Step 5 is the targeted assertion against this specific bug; steps 4 is the broader functional guarantee.

## Test plan

- [ ] `go test -race ./internal/selfupgrade/...` — green locally (verified 5× with `-count=5`).
- [ ] Full CI green (Test matrix + CodeQL + Socket + Analyze).
- [ ] After merge, this lands in v0.8.1 alongside any other fixes that accumulate.