### PR TITLE
Pin staticcheck, gosec, govulncheck via mise

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -14,6 +14,17 @@ cosign 3.0.6
 shellcheck 0.11.0
 syft 1.42.4
 caddy 2.11.2
+# Go quality and vulnerability tooling consumed by `task lint` (staticcheck +
+# gosec) and `task vuln-check` (govulncheck). Pinning via mise — rather than
+# `go install ...@latest` — keeps these reproducible across machines and
+# survives Go toolchain bumps (a `go install` binary lives in the active
+# Go's bin dir and is shadowed the moment Go's version moves). staticcheck
+# and gosec install as aqua-verified prebuilt binaries; govulncheck has no
+# aqua prebuilt and compiles from source via the `go:` backend. Bump these
+# intentionally — re-run `task lint && task vuln-check` after each bump.
+staticcheck 2026.1
+aqua:securego/gosec 2.26.1
+go:golang.org/x/vuln/cmd/govulncheck 1.3.0
 # websocat: hand-rolled WebSocket testing for the `truestamp console`
 # wire protocol. See docs/engineering/console.md and the upstream
 # truestamp-v2/docs/console_channel.md "Hand-rolled testing" recipe.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -190,7 +190,7 @@ tasks:
       - go vet ./...
 
   lint:
-    desc: "All quality checks: vet + fmt-check + staticcheck + gosec. Install the last two via: go install honnef.co/go/tools/cmd/staticcheck@latest && go install github.com/securego/gosec/v2/cmd/gosec@latest"
+    desc: "All quality checks: vet + fmt-check + staticcheck + gosec. staticcheck and gosec are pinned in .tool-versions and installed by `mise install`."
     deps: [vet, fmt-check]
     cmds:
       - staticcheck ./...
@@ -212,7 +212,7 @@ tasks:
       - gosec -quiet -exclude-dir=testdata -exclude=G104,G115,G301,G302,G306,G304,G401,G501,G505,G204,G704 ./...
 
   vuln-check:
-    desc: "Scan go.mod deps for known vulnerabilities. Install via: go install golang.org/x/vuln/cmd/govulncheck@latest"
+    desc: "Scan go.mod deps for known vulnerabilities. govulncheck is pinned in .tool-versions and installed by `mise install`."
     cmds:
       - govulncheck ./...
 


### PR DESCRIPTION
## Summary
- Add `staticcheck` (2026.1), `aqua:securego/gosec` (2.26.1), and `go:golang.org/x/vuln/cmd/govulncheck` (1.3.0) to `.tool-versions` so `mise install` provisions them alongside the rest of the toolchain.
- staticcheck and gosec install as aqua-verified prebuilt binaries; govulncheck has no aqua prebuilt and compiles via the `go:` backend.
- Update the `lint` and `vuln-check` descriptions in `Taskfile.yml` to point at `mise install` rather than telling readers to run `go install ...@latest` by hand.

## Motivation
A fresh clone trips on `task precommit` because the `lint` task's documented `go install` commands haven't been run. Two structural problems with the old approach:

1. `go install` binaries land in the *active* Go's bin dir (`~/.local/share/mise/installs/go/<version>/bin/` under mise). When the Go pin bumps — exactly what we did from 1.26.2 → 1.26.3 — the previously installed tools are silently shadowed and have to be reinstalled. This will happen again every Go bump.
2. There is no version pinning or supply-chain verification of those binaries — `@latest` drifts, and there's no signature check on the resulting executable.

Moving them into `.tool-versions` fixes both: versions are pinned (in line with the file's existing "never use latest" rule), the tools persist across Go upgrades because they live under their own `installs/<tool>/<version>/` path, and the two aqua entries get the same supply-chain checks mise already applies to `cosign` and `goreleaser`.

## Test plan
- [x] `mise install` idempotently resolves all 14 tools, including the 3 new ones
- [x] `task precommit` passes end-to-end (fmt + vet + staticcheck + gosec + tests across all 27 packages + build)
- [x] `task vuln-check` passes — "No vulnerabilities found"
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)