### PR TITLE
Add OAuth2-first auth, API key as fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ coverage/
 
 # Claude Code local settings
 .claude/settings.local.json
+
+# CLI <-> server OAuth migration coordination log (never commit)
+CHAT.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **OAuth 2.1 browser sign-in, now the primary authentication method.**
+  `truestamp auth login` opens the browser and runs a loopback
+  Authorization Code + PKCE (S256) flow, storing a short-lived access
+  token plus a rotating refresh token in the OS keychain (with a 0600
+  file fallback). A new `internal/auth` package unifies OAuth and the
+  long-lived API key behind a single process-wide `Authorizer`:
+  discovery-driven endpoints (RFC 8414) validated with issuer and
+  same-origin pinning, a self-managed token cache that refreshes
+  proactively and on demand, automatic single-use refresh-token
+  rotation, and a reactive 401 → refresh → retry-once transport on the
+  shared HTTP client. The six existing API call sites (`auth`, `team`,
+  `beacon`, `create`, `download`, `verify --remote`) and the `console`
+  WebSocket all authenticate through it. `auth login --api-key` keeps
+  the interactive paste-a-key path; `auth logout` revokes the refresh
+  token (RFC 7009) and clears the session; `auth status` and
+  `config show` report the active credential, scopes, and token expiry.
+- **Console WebSocket OAuth with an in-band keep-alive.** The console
+  authenticates on the upgrade with an `access_token` query param and
+  keeps a long session alive across token rotation without
+  reconnecting: it proactively refreshes and pushes `token.refresh`
+  over the live socket before expiry, with the server's `token_expired`
+  push as a reactive refresh-and-redial safety net and a
+  stop-and-prompt-re-login path for a dead session.
+
+### Changed
+- **Authentication is OAuth-first, API-key-second.** A long-lived API
+  key remains the CI/headless path via `--api-key` or
+  `TRUESTAMP_API_KEY`; an explicitly-provided key takes precedence over
+  a stored OAuth session so automated environments stay deterministic.
+  Help text, `config show`, and the "not authenticated" guidance across
+  `team` / `beacon` / `create` / `download` / `verify` / `console` were
+  reworded for the new model. Secret redaction was extended to OAuth
+  access/refresh tokens, authorization codes, and PKCE verifiers in both
+  query-string and JSON forms. New fuzz targets `FuzzDiscoveryValidate`
+  and `FuzzSessionDecode` harden the discovery-document and token-store
+  parsers.
+
+### Security
+- New dependencies `golang.org/x/oauth2`, `github.com/zalando/go-keyring`,
+  and `github.com/cli/browser`. Refresh tokens live in the OS keychain
+  (0600 file fallback), never in `config.toml`; access tokens are
+  short-lived; the loopback callback enforces the PKCE `state` before
+  accepting an authorization code; and the discovery document's endpoints
+  are pinned to the configured origin.
+
 ## [0.8.2] — 2026-06-11
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,9 @@ Go CLI tool that cryptographically verifies Truestamp proof bundle JSON files. C
 
 Beyond verification, the CLI exposes five Unix-y, pipe-friendly sub-commands that replace the common external tool chain (`sha256sum`, `shasum`, `xxd`, `base64`, `jq`, `date`): `truestamp hash` (digests), `truestamp encode` / `truestamp decode` (byte encodings), `truestamp jcs` (RFC 8785 canonicalization), `truestamp convert {time, proof, id, keyid, merkle}` (domain conversions). `truestamp create` registers a new timestamped item in either of two modes: **external-hash** (the user submits a hash of a file they keep locally) or **claims-as-source-of-truth** (no external file — the claims content itself is what gets timestamped, gated by a server-side meaningful-content rule requiring ≥ 32-char description or non-empty metadata). The pair `claims.hash` / `claims.hash_type` is co-required: both supplied or both omitted.
 
-`truestamp console` opens an interactive Bubble Tea TUI that holds a long-lived authenticated WebSocket to the backend (multiplexed Phoenix Channels: `console:lobby` for commands + stream events, `console:clock` for server-time ticks). Four panes — Monitor (toggleable stream subscriptions + scrollable waterfall), New Item (two-mode form — external-hash or claims-as-source-of-truth, picked via a leading `Submission mode` Select; hash + hash_type fields are auto-hidden in claims-content mode and the description field enforces the ≥ 32-char rule inline — plus live `items.created → items.committed` lifecycle card), Teams (membership list + in-place team switch via `scope.switch_team` channel push), Connection (diagnostics + log file path). Reconnect-with-backoff, server-side first-event-immediate event coalescing into `<resource>.burst` summaries, and 24h time-windowed event retention. Full architecture, limits, logging, and testing in [docs/engineering/console.md](docs/engineering/console.md). Server wire protocol authoritative reference in [truestamp-v2/docs/console_channel.md](https://github.com/truestamp/truestamp-v2/blob/main/docs/console_channel.md).
+Authentication is **OAuth-first, API-key-second**. `truestamp auth login` opens the browser and runs a loopback Authorization Code + PKCE flow (OAuth 2.1), storing a short-lived access token plus a rotating refresh token in the OS keychain (with a 0600-file fallback). A long-lived API key (`--api-key` / `TRUESTAMP_API_KEY`, or `auth login --api-key` written to config.toml) remains the CI/headless fallback and, when supplied explicitly, takes precedence over a stored OAuth session. The core lives in the new [`internal/auth`](internal/auth/) package, which unifies both credentials behind a single process-wide `Authorizer`. See "Authentication" below.
+
+`truestamp console` opens an interactive Bubble Tea TUI that holds a long-lived authenticated WebSocket to the backend (multiplexed Phoenix Channels: `console:lobby` for commands + stream events, `console:clock` for server-time ticks). The WebSocket sends the OAuth access token as an `?access_token=<jwt>` query param on the upgrade (a Phoenix upgrade can't read the `Authorization` header; an API key stays a `?api_key=` query param); on the server's `token_expired` push it force-refreshes the token, re-dials, and re-joins topics, while a dead session (`invalid_grant`) stops reconnect and prompts re-login. Four panes — Monitor (toggleable stream subscriptions + scrollable waterfall), New Item (two-mode form — external-hash or claims-as-source-of-truth, picked via a leading `Submission mode` Select; hash + hash_type fields are auto-hidden in claims-content mode and the description field enforces the ≥ 32-char rule inline — plus live `items.created → items.committed` lifecycle card), Teams (membership list + in-place team switch via `scope.switch_team` channel push), Connection (diagnostics + log file path). Reconnect-with-backoff, server-side first-event-immediate event coalescing into `<resource>.burst` summaries, and 24h time-windowed event retention. Full architecture, limits, logging, and testing in [docs/engineering/console.md](docs/engineering/console.md). Server wire protocol authoritative reference in [truestamp-v2/docs/console_channel.md](https://github.com/truestamp/truestamp-v2/blob/main/docs/console_channel.md).
 
 The `truestamp team` subcommand (`team list / show / set / unset`) and the in-TUI Teams pane share a single source of truth: the top-level `team` key in `~/.config/truestamp/config.toml`. `team set` validates the id by reading the team from `/api/json/teams/{id}` before persisting, so a typo or revoked membership refuses to write. The console pane's `s`-to-set confirmation pushes `scope.switch_team` over the live WebSocket, persists on success, and never reconnects — catalog stream subscriptions get rebound against the new tenant server-side, while item watches keep their original team binding. See "Team management surfaces" below.
 
@@ -50,6 +52,9 @@ task build                    # -> build/truestamp
 ./build/truestamp team show [id]                                       # detail card for active team (or arg)
 ./build/truestamp team set [id]                                        # validate + persist; interactive picker if no id
 ./build/truestamp team unset                                           # clear active team in config.toml
+./build/truestamp auth login [--api-key]                               # browser OAuth (default); --api-key = interactive paste into config.toml
+./build/truestamp auth logout [--api-key]                             # revoke + clear OAuth session; --api-key also clears the stored key
+./build/truestamp auth status                                         # mode-aware: Auth Mode, scopes, token expiry, team
 ./build/truestamp config path|show|init
 ./build/truestamp upgrade [--check] [--yes] [--version vX.Y.Z]
 ./build/truestamp version      # includes detected install method (homebrew / go install / install.sh / unknown)
@@ -97,6 +102,8 @@ Settings are resolved in priority order (highest priority last):
 3. Environment variables (`TRUESTAMP_` prefix)
 4. CLI flags (only explicitly set flags override)
 
+Authentication is OAuth-first: the access/refresh token pair lives in the **OS keychain** (0600-file fallback), *not* in config.toml. The config-file `api_key` and the explicit `--api-key` / `TRUESTAMP_API_KEY` are the CI/headless path only; an explicit key (env or flag, tracked as `config.Config.APIKeyExplicit`, computed in `config.Load`) overrides a stored OAuth session, while a config-file key is consulted only after the OAuth session. See "Authentication" below for the full precedence.
+
 ### Config Commands
 
 | Command | Description |
@@ -111,7 +118,7 @@ Settings are resolved in priority order (highest priority last):
 | ---- | ------- | ------- | ----------- |
 | `--config` | | `~/.config/truestamp/config.toml` | Path to config file |
 | `--api-url` | `TRUESTAMP_API_URL` | `https://www.truestamp.com/api/json` | Base URL of the Truestamp API |
-| `--api-key` | `TRUESTAMP_API_KEY` | `""` | API key for authentication |
+| `--api-key` | `TRUESTAMP_API_KEY` | `""` | Long-lived API key — the CI/headless fallback. Supplying it explicitly (this flag or the env var) overrides any stored OAuth session; a config-file `api_key` ranks below the OAuth session. OAuth is the default; prefer `truestamp auth login`. |
 | `--keyring-url` | `TRUESTAMP_KEYRING_URL` | `https://www.truestamp.com/.well-known/keyring.json` | URL of keyring endpoint |
 | `--http-timeout` | `TRUESTAMP_HTTP_TIMEOUT` | `10s` | HTTP timeout for external API calls |
 | `--no-color` | `NO_COLOR` | `false` | Disable all color and ANSI output |
@@ -199,6 +206,39 @@ Every post-action card uses `ui.CompactTable()` which returns a lipgloss table w
 | `convert merkle [ip-value]` | `--json`, `--silent` (positional or stdin) |
 
 Env vars: `TRUESTAMP_CONVERT_TIME_ZONE` sets the default `--to-zone` for `convert time` and `convert id`.
+
+## Authentication
+
+Authentication is **OAuth-first, API-key-second**, unified behind a single `auth.Authorizer` ([`internal/auth/auth.go`](internal/auth/auth.go)). One `Authorizer` is resolved once in `cmd/root.go`'s `PersistentPreRunE` and installed process-wide via `auth.SetDefault`; every authenticated call site draws from `auth.Default()`.
+
+**Precedence** ([`internal/auth.Resolve`](internal/auth/resolve.go)):
+
+1. **Explicit API key** — `--api-key` flag or `TRUESTAMP_API_KEY` env (`Credentials.APIKeyExplicit`). Wins outright so CI/headless is deterministic.
+2. **Stored OAuth session** — access token, auto-refreshed via the rotating refresh token.
+3. **Config-file `api_key`** — a key sitting in config.toml (not "explicit").
+4. **None** — unauthenticated; public requests still go out, the server 401s on protected ones.
+
+Both an OAuth access token and an API key are presented to the JSON API as `Authorization: Bearer <value>`; the server accepts either.
+
+**OAuth flow** — browser-based loopback Authorization Code + PKCE (S256 only), `golang.org/x/oauth2`. Public client: the `client_id` `019ef661-6737-71ec-abd0-ac8f4684ce45` (a UUIDv7 — the server's `oauth_clients` PK type rejects non-v7 ids) is baked in ([`auth.ClientID`](internal/auth/auth.go), `token_endpoint_auth_method=none` — PKCE is the per-flow secret); every endpoint (issuer / authorize / token / revocation) comes from RFC 8414 discovery ([`discovery.go`](internal/auth/discovery.go)), validated with issuer-match + same-origin endpoint pinning. The loopback redirect binds **fixed ports** `127.0.0.1:8976` (primary) → `:8765` (fallback), exact-matched server-side ([`login.go`](internal/auth/login.go) `loopbackPorts`). Requested `Scopes` = `api:read api:write console:read console:write` (no `mcp:*`).
+
+**Commands** ([`cmd/auth.go`](cmd/auth.go)):
+
+- `auth login` — browser OAuth by default; `--api-key` switches to an interactive paste-a-key path that writes the key to config.toml (0600).
+- `auth logout` — best-effort RFC 7009 `/oauth/revoke` of the refresh token + clear the local session; `--api-key` additionally removes the stored config-file key. Idempotent.
+- `auth status` — mode-aware: renders **Auth Mode**, plus (in OAuth mode) scopes and token expiry, then validates the credential against `/users` and resolves the team. `config show` also gained an **Auth Mode** row (`cmd/config.go` `authModeDisplay`).
+
+**Storage** ([`store.go`](internal/auth/store.go)) — `Session` (access + rotating refresh token + cached endpoint URLs + scope/expiry) persisted per server origin in the OS keychain (`zalando/go-keyring`), transparently falling back to a 0600 JSON file under the user cache dir (`truestamp/oauth.json`) on a keychain-less host. The refresh token rotates on every refresh; the rotated value is persisted best-effort after each grant ([`resolve.go`](internal/auth/resolve.go) `oauthAuthorizer.token`).
+
+**Reactive 401 retry** — `auth.NewRetryTransport(nil)` is layered onto the shared HTTP client (`httpclient.SetTransport`, wired in `cmd/root.go`). In OAuth mode a `401` on a request *we* authenticated triggers one `ForceRefresh` + retry; the server's OAuth→API-key fallback means an expired token can surface as a bare 401 with no `WWW-Authenticate`, so the contract is "any 401 in OAuth mode ⇒ refresh-and-retry-once" — centralized here for every call site. A dead session (`invalid_grant` ⇒ `ErrSessionExpired`) is not retried.
+
+**Call-site routing** — the six former Bearer-header sites (`cmd/auth.go` `checkAuth`/`fetchTeam`, `internal/teams`, `internal/beacons`, `internal/items`, `internal/proof/download.go`, `internal/verify/remote.go`) now authorize through `auth.AuthorizeRequest` / `auth.Default()`; their `Config`/params no longer carry an api key.
+
+**WebSocket** — see "Console" below: OAuth sends the access token as an `?access_token=` query param on the upgrade (a Phoenix upgrade can't read the `Authorization` header; api key stays `?api_key=`), with a `token_expired` → force-refresh → re-dial → re-join recovery and a dead-session stop.
+
+**Secret redaction** ([`internal/redact`](internal/redact/redact.go)) — the single redaction source (used by `internal/logging` and `internal/wschannel`) was extended to scrub `access_token` / `refresh_token` / `code` / `code_verifier` (query-string and JSON forms) alongside the existing `api_key=…` / `Bearer …` patterns, plus `redact.WrapError` (redacts `Error()` while preserving `errors.Is`/`errors.As` through the chain — used so a token error stays `errors.Is(ErrSessionExpired)` for the WS fatal-session check without leaking bytes).
+
+**In-band keep-alive** — `internal/wschannel`'s `keepAliveLoop` polls and, ~60s before the access token expires, force-refreshes it and pushes `token.refresh {"access_token": <jwt>}` on `console:lobby` over the live socket. The server re-validates and reschedules its disconnect timer (`{:ok, %{exp}}`), so a long console session re-authenticates **without** reconnecting and `token_expired` never fires. Any failure (dead session, rejected token, delivery hiccup) falls back to the reactive `token_expired` → re-dial path. Wired via `wschannel.Options.AccessTokenExpiry` ← `auth.Authorizer.AccessTokenExpiry`.
 
 ## Proof Bundle Format
 
@@ -321,10 +361,10 @@ Bitcoin regtest has no public API -- local crypto verification only.
 ```
 main.go                         Entry point
 cmd/
-  root.go                       Cobra root command, persistent flags, config loading, PostRun hook for passive upgrade notices
+  root.go                       Cobra root command, persistent flags, config loading; PersistentPreRunE resolves + installs the process-wide auth.Authorizer and layers httpclient.SetTransport(auth.NewRetryTransport(nil)); PostRun hook for passive upgrade notices
   verify.go                     Verify subcommand (uses inputsrc for the six-mode input resolver)
   create.go                     Create subcommand (item registration; shares inputsrc sentinels)
-  auth.go                       Auth login/logout/status subcommand
+  auth.go                       Auth login/logout/status subcommand (OAuth-first; --api-key paste path, best-effort revoke on logout, mode-aware status; authorizes /users + /teams probes through auth.Authorizer)
   beacon.go                     beacon parent + `latest` default (maps `truestamp beacon` → latest)
   beacon_list.go                beacon list (table rendering, TTY-aware hash truncation)
   beacon_get.go                 beacon get (client-side UUIDv7 validation)
@@ -341,7 +381,7 @@ cmd/
   convert_keyid.go              convert keyid (Ed25519 pubkey -> 4-byte Truestamp kid)
   convert_merkle.go             convert merkle (decode compact base64url Merkle proof)
   config.go                     Config subcommand (path, show, init)
-  console.go                    Console subcommand (Bubble Tea TUI over authenticated WebSocket; --ws-url, --log-level, --log-file flags). See docs/engineering/console.md.
+  console.go                    Console subcommand (Bubble Tea TUI over authenticated WebSocket; --ws-url, --log-level, --log-file flags); passes auth.Default() to console.Options.Authorizer. See docs/engineering/console.md.
   upgrade.go                    Upgrade subcommand + flags (install-method routing, exitCodeErr contract)
   upgrade_test.go               upgradeInstructionFor routing + readYes + ExitCode tests
   verify_test.go                CLI integration tests (builds binary, tests exit codes)
@@ -349,8 +389,15 @@ cmd/
   codec_test.go                 encode/decode/jcs integration tests
   convert_test.go               convert integration tests (time zones, ID extraction, proof round-trip)
 internal/
+  auth/
+    auth.go                     Authorizer interface + Mode; process-wide Default/SetDefault/AuthorizeRequest; baked-in public ClientID, Scopes, fixed loopback ports, ErrNoCredentials/ErrSessionExpired
+    discovery.go                RFC 8414 metadata Fetch + Validate (issuer-match + same-origin endpoint pinning)
+    login.go                    Browser loopback Authorization Code + PKCE (S256) flow; Logout + RFC 7009 revoke
+    store.go                    Session + per-origin store (OS keychain via zalando/go-keyring, 0600-file fallback)
+    resolve.go                  Credentials, Resolve precedence, the 3 Authorizer impls (apiKey/none/oauth), self-managed token cache with ForceRefresh, reactive 401-retry RoundTripper (NewRetryTransport), IsInvalidGrant
+    auth_test.go                Resolve precedence + discovery validation + retry-transport + store round-trip tests
   config/
-    config.go                   koanf-based config loading, XDG paths, validation
+    config.go                   koanf-based config loading, XDG paths, validation; computes APIKeyExplicit (env/flag = explicit, config-file = not) for the auth resolver
     defaults/
       config.toml               Embedded default config (go:embed)
   beacons/
@@ -407,22 +454,26 @@ internal/
     bitcoin.go                  GET Blockstream API
     external_test.go            HTTP mock tests (httptest)
   httpclient/
-    client.go                   Shared HTTP client, GetJSONCtx for small JSON responses
+    client.go                   Shared HTTP client, GetJSONCtx for small JSON responses; SetTransport installs the auth 401-retry RoundTripper
     download.go                 DownloadCtx (streams to disk, 200MB cap) + DownloadBytesCtx (in-memory, cap configurable)
     download_test.go            httptest-server tests for happy path, oversize, HTTP error, context cancellation
   console/
-    app.go                      Bubble Tea root model, header (with reconnect countdown + server-time clock), footer key hints, pane switching
+    app.go                      Bubble Tea root model, header (with reconnect countdown + server-time clock), footer key hints, pane switching; maps Options.Authorizer → wschannel.Options (OAuth ⇒ BearerToken/ForceRefresh/FatalDialErr; API key ⇒ resolved once for the query param)
     monitor.go                  Monitor pane: stream toggle list + scrollable / reversible event waterfall (24h time-windowed retention, 100k hard cap)
     newitem.go                  New Item form pane: 4-field input + items.create round-trip + per-item lifecycle card (capped at 100 transitions)
     connection.go               Connection pane: scope, push counts, reconnect summary, log file path
-    messages.go                 tea.Msg types + waitForPush bridge between WS reader goroutine and tea.Update; routes server-time ticks, rejoin events, reconnect status
+    connerror.go                Dial-error classifier; a dead/absent OAuth session (ErrSessionExpired/ErrNoCredentials) routes to the "re-authenticate" hint instead of a network error
+    messages.go                 tea.Msg types + waitForPush bridge between WS reader goroutine and tea.Update; routes server-time ticks, rejoin events, reconnect status, plus tokenRefreshingMsg / authFailedMsg from the OAuth refresh path
   wschannel/
-    client.go                   Homegrown Phoenix Channels V2 client. Multi-topic on one socket; reconnect-with-backoff (1→2→5→10→30s); rejoinAllTopics replay; api_key redaction; two-stage readiness gate (socketReady / sessionReady); pending-call drain on disconnect
+    client.go                   Homegrown Phoenix Channels V2 client. Multi-topic on one socket; reconnect-with-backoff (1→2→5→10→30s); rejoinAllTopics replay; redaction; two-stage readiness gate (socketReady / sessionReady); pending-call drain on disconnect. Options.{BearerToken,ForceRefresh,FatalDialErr,AccessTokenExpiry} drive OAuth: access_token query param on the upgrade (api key stays ?api_key=), token_expired → force-refresh → re-dial → re-join, dead session (authDead) stops reconnect via TokenRefreshEvent / AuthFailedEvent, plus the proactive in-band token.refresh keep-alive
     codec.go                    Phoenix V2 array-form Frame encoder/decoder + ParseReply
-    redact_test.go              Security-critical: api_key never leaks in logs OR returned errors
+    redact_test.go              Security-critical: api_key / Bearer token never leaks in logs OR returned errors
     smoke_test.go               Live-server tests gated behind `smoke` build tag (TestSmokeConsoleLobby, TestSmokeClockTopic, TestSmokeLiveBlock, TestSmokeReconnect)
+  redact/
+    redact.go                   Single redaction source (used by logging + wschannel): api_key=… / Bearer … plus OAuth access_token/refresh_token/code/code_verifier (query + JSON); String/Error/WrapError (WrapError redacts Error() while preserving errors.Is/As)
+    redact_test.go              Asserts every secret pattern is scrubbed in query, JSON, and error-chain forms
   logging/
-    logging.go                  slog + lumberjack file logger (10MB rotation, 5 backups, 14d retention, gzip). Default path: $UserCacheDir/truestamp/console.log. Also exports DefaultPath() for flag help text.
+    logging.go                  slog + lumberjack file logger (10MB rotation, 5 backups, 14d retention, gzip). Default path: $UserCacheDir/truestamp/console.log. Also exports DefaultPath() for flag help text. RedactingHandler routes every attribute through internal/redact.
   ui/
     ui.go                       Shared lipgloss v2 styling: renderer, adaptive colors, components
   verify/
@@ -430,12 +481,13 @@ internal/
     report.go                   Step, Status, Report types
     presenter.go                Lipgloss v2 rendering of Report (table, list, tree)
     json_output.go              Structured JSON output for --json mode
-    remote.go                   Remote API verification
+    remote.go                   Remote API verification (authorizes the /proof/verify POST through auth.Default())
     verify_test.go              Orchestrator unit tests
 ```
 
 ## Architecture Notes
 
+- **Authentication is a single process-wide chokepoint**: `cmd/root.go`'s `PersistentPreRunE` resolves one `auth.Authorizer` via `auth.Resolve` (precedence: explicit `--api-key`/`TRUESTAMP_API_KEY` → stored OAuth session → config-file `api_key` → none) and installs it with `auth.SetDefault`, mirroring `httpclient`'s package-global pattern so the existing call sites authorize via `auth.AuthorizeRequest`/`auth.Default()` without threading an authorizer through every signature. OAuth and the API key are unified behind the same `Authorizer` (both presented as `Authorization: Bearer <value>` to the JSON API). A reactive **401 → ForceRefresh → retry-once** `http.RoundTripper` (`auth.NewRetryTransport`) is layered onto the shared client via `httpclient.SetTransport`, so a server-rejected OAuth access token self-heals without a spurious auth failure; only OAuth-mode requests *we* authenticated are retried, and a dead session (`invalid_grant` ⇒ `ErrSessionExpired`) is not. OAuth tokens live in the OS keychain (0600-file fallback), never config.toml; the refresh token rotates on every refresh. Full model in the "Authentication" section above.
 - **Logic/presentation separation**: `verify.go` builds a `Report` with `Step` entries (pure logic, no I/O). `presenter.go` renders the report to stdout using lipgloss v2 table/list/tree. `report.go` defines the types and `Passed()`/`FailedCount()` methods.
 - **Shared UI package**: `internal/ui/ui.go` provides the shared lipgloss v2 styling foundation (adaptive color palette, HeaderBox, SectionHeader, banners). Uses `compat.AdaptiveColor` for light/dark terminal support. `--no-color` flag sets `lipgloss.Writer.Profile = NoTTY` to strip all ANSI. The `NO_COLOR` env var is natively respected by lipgloss.
 - **`tscrypto` package**: Named to avoid shadowing Go's stdlib `crypto` package. No import alias needed.

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -11,10 +11,12 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"charm.land/huh/v2"
 	lipgloss "charm.land/lipgloss/v2"
 	"github.com/spf13/cobra"
+	"github.com/truestamp/truestamp-cli/internal/auth"
 	"github.com/truestamp/truestamp-cli/internal/config"
 	"github.com/truestamp/truestamp-cli/internal/httpclient"
 	"github.com/truestamp/truestamp-cli/internal/teams"
@@ -23,43 +25,58 @@ import (
 
 var authCmd = &cobra.Command{
 	Use:   "auth",
-	Short: "Manage Truestamp API authentication",
-	Long:  "Log in to store your Truestamp API key in the config file, or log out to remove it.",
+	Short: "Manage Truestamp authentication",
+	Long: `Sign in to Truestamp.
+
+By default 'auth login' opens your browser for a secure OAuth sign-in
+(Authorization Code + PKCE). The resulting session uses a short-lived
+access token that the CLI refreshes automatically, and the refresh token
+is stored in your OS keychain (with a 0600 file fallback).
+
+For CI and other headless environments, set a long-lived API key via the
+TRUESTAMP_API_KEY env var or the --api-key flag; an explicitly-provided API
+key takes precedence over an OAuth session. 'auth login --api-key' stores a
+key in your config file interactively.`,
 }
+
+var authLoginAPIKey bool
 
 var authLoginCmd = &cobra.Command{
 	Use:   "login",
-	Short: "Store an API key in the config file",
-	Long: `Log in by pasting a Truestamp API key.
+	Short: "Sign in via your browser (OAuth), or store an API key with --api-key",
+	Long: `Sign in to Truestamp.
 
-Visit the API keys page in the Truestamp web app, create a new key, and copy
-it immediately — existing keys cannot be copied after creation. Paste the
-new key into the interactive prompt. The key is stored in your local config
-file with 0600 permissions. For security, there is no command-line flag to
-accept the key — it must be pasted into the hidden-input prompt.`,
+Default: opens your browser to authorize the CLI (OAuth 2.1 Authorization
+Code + PKCE). On success a session is stored in your OS keychain (0600 file
+fallback) and refreshed automatically.
+
+--api-key: instead prompts for a long-lived API key and stores it in the
+config file with 0600 permissions (the headless/CI path).`,
 	Args:          cobra.NoArgs,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE:          runAuthLogin,
 }
 
+var authLogoutAPIKey bool
+
 var authLogoutCmd = &cobra.Command{
 	Use:   "logout",
-	Short: "Remove the stored API key from the config file",
+	Short: "Sign out — revoke the OAuth session and/or remove the stored API key",
 	Args:  cobra.NoArgs,
 	RunE:  runAuthLogout,
 }
 
 var authStatusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Report whether an API key is configured and valid",
-	Long: `Report whether an API key is configured and validate it by calling
-the Truestamp API. This is inherently an online operation; no offline mode
-is offered.
+	Short: "Report the active credential and validate it against the API",
+	Long: `Report which credential is active (OAuth session or API key) and
+validate it by calling the Truestamp API. This is inherently an online
+operation; no offline mode is offered.
 
 Exit codes:
-  0  valid (key is set and accepted by the API)
-  1  no key, invalid key, or network error`,
+  0  valid (a credential is active and accepted by the API)
+  1  no credential, invalid credential, or network error`,
 	Args:          cobra.NoArgs,
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -67,15 +84,84 @@ Exit codes:
 }
 
 func init() {
+	authLoginCmd.Flags().BoolVar(&authLoginAPIKey, "api-key", false, "Store a long-lived API key interactively instead of OAuth sign-in")
+	authLogoutCmd.Flags().BoolVar(&authLogoutAPIKey, "api-key", false, "Remove the stored API key (in addition to clearing any OAuth session)")
 	authCmd.AddCommand(authLoginCmd)
 	authCmd.AddCommand(authLogoutCmd)
 	authCmd.AddCommand(authStatusCmd)
 	rootCmd.AddCommand(authCmd)
 }
 
+// runAuthLogin dispatches to the browser OAuth flow (default) or the
+// interactive API-key paste path (--api-key).
 func runAuthLogin(cmd *cobra.Command, _ []string) error {
+	if authLoginAPIKey {
+		return runAPIKeyLogin(cmd)
+	}
+	return runOAuthLogin(cmd)
+}
+
+// runOAuthLogin runs the browser-based loopback OAuth flow.
+func runOAuthLogin(cmd *cobra.Command) error {
+	out := cmd.OutOrStdout()
+	cfg := appConfig
+	store := auth.NewStore(cfg.BaseURL)
+
+	// The browser flow needs an interactive session to be useful, but we
+	// don't hard-require a TTY: the URL is printed so a user on a headless
+	// box can copy it. We do warn if an explicit API key will shadow the
+	// session for actual API calls.
+	if cfg.APIKeyExplicit {
+		fmt.Fprintln(cmd.ErrOrStderr(), ui.FaintStyle().Render(
+			"note: TRUESTAMP_API_KEY/--api-key is set and takes precedence over an OAuth session for API calls."))
+	}
+
+	fmt.Fprintln(out, ui.HeaderBox("Truestamp Sign-In", "Authorizing via your browser"))
+	fmt.Fprintln(out)
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Minute)
+	defer cancel()
+
+	sess, err := auth.Login(ctx, cfg.BaseURL, store, auth.LoginOptions{Out: out})
+	if err != nil {
+		return fmt.Errorf("login failed: %w", err)
+	}
+	appLogger.Info("auth_login_oauth", "issuer", sess.Issuer, "scope", sess.Scope)
+
+	// Re-resolve the process authorizer so subsequent calls (and the probe
+	// below) see the new session.
+	auth.SetDefault(auth.Resolve(
+		auth.Credentials{APIKey: cfg.APIKey, APIKeyExplicit: cfg.APIKeyExplicit}, store))
+
+	// Best-effort identity probe using the freshly-minted OAuth session
+	// specifically (ignoring any api-key precedence) so the confirmation
+	// reflects who you just signed in as.
+	probe := auth.Resolve(auth.Credentials{}, store)
+	identity := ""
+	if res, perr := checkAuth(ctx, probe, cfg.APIURL, cfg.Team); perr == nil && res.ok {
+		identity = formatUserIdentity(res)
+	}
+
+	labelStyle := lipgloss.NewStyle().Foreground(ui.Label)
+	if identity != "" {
+		fmt.Fprintln(out, ui.SuccessBanner("Signed in as "+identity))
+	} else {
+		fmt.Fprintln(out, ui.SuccessBanner("Signed in"))
+	}
+	if sess.Scope != "" {
+		fmt.Fprintln(out, labelStyle.Render("    Scopes:  "+sess.Scope))
+	}
+	if !sess.Expiry.IsZero() {
+		fmt.Fprintln(out, labelStyle.Render("    Expires: "+sess.Expiry.Local().Format(time.RFC1123)+" (auto-refreshed)"))
+	}
+	fmt.Fprintln(out, labelStyle.Render("    Stored:  "+store.Location()))
+	return nil
+}
+
+// runAPIKeyLogin is the legacy interactive paste-a-key path (--api-key).
+func runAPIKeyLogin(cmd *cobra.Command) error {
 	if !stdinIsTerminal() {
-		return fmt.Errorf("auth login requires an interactive terminal")
+		return fmt.Errorf("auth login --api-key requires an interactive terminal (set TRUESTAMP_API_KEY directly in CI)")
 	}
 
 	keysURL, err := apiKeysURL(appConfig.APIURL)
@@ -124,52 +210,98 @@ func runAuthLogin(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	// Log the action — never the key bytes. The redacting handler
-	// would catch a leak, but we don't put the key into attrs at all.
-	appLogger.Info("auth_login", "config_path", config.ConfigFilePath())
-	fmt.Fprintln(out, ui.SuccessBanner("Logged in — API key saved to "+config.ConfigFilePath()))
+	// Log the action — never the key bytes.
+	appLogger.Info("auth_login_apikey", "config_path", config.ConfigFilePath())
+	fmt.Fprintln(out, ui.SuccessBanner("API key saved to "+config.ConfigFilePath()))
 	return nil
 }
 
+// runAuthLogout revokes any OAuth session and optionally clears a stored
+// API key. By default it clears whatever credential is active; --api-key
+// additionally removes the stored config-file key.
 func runAuthLogout(cmd *cobra.Command, _ []string) error {
 	out := cmd.OutOrStdout()
+	cfg := appConfig
+	store := auth.NewStore(cfg.BaseURL)
 
-	if appConfig.APIKey == "" {
-		fmt.Fprintln(out, ui.FaintStyle().Render("  No API key is currently stored."))
+	_, oauthErr := store.Load()
+	hasOAuth := oauthErr == nil
+	hasFileKey := cfg.APIKey != "" && !cfg.APIKeyExplicit
+
+	if !hasOAuth && !hasFileKey {
+		if cfg.APIKeyExplicit {
+			fmt.Fprintln(out, ui.FaintStyle().Render(
+				"  Authenticated via TRUESTAMP_API_KEY/--api-key — nothing is stored to clear."))
+			fmt.Fprintln(out, ui.FaintStyle().Render(
+				"  Unset it in your environment to sign out."))
+		} else {
+			fmt.Fprintln(out, ui.FaintStyle().Render("  Not logged in."))
+		}
 		return nil
 	}
 
-	if !stdinIsTerminal() {
-		return fmt.Errorf("auth logout requires an interactive terminal")
+	if stdinIsTerminal() {
+		var confirmed bool
+		desc := logoutDescription(hasOAuth, hasFileKey || authLogoutAPIKey)
+		if err := huh.NewForm(
+			huh.NewGroup(
+				huh.NewConfirm().
+					Title("Sign out?").
+					Description(desc).
+					Affirmative("Yes, sign out").
+					Negative("Cancel").
+					Value(&confirmed),
+			),
+		).WithTheme(ui.HuhTheme()).Run(); err != nil {
+			return fmt.Errorf("confirmation: %w", err)
+		}
+		if !confirmed {
+			fmt.Fprintln(out, ui.FaintStyle().Render("  Cancelled."))
+			return nil
+		}
 	}
 
-	var confirmed bool
-	err := huh.NewForm(
-		huh.NewGroup(
-			huh.NewConfirm().
-				Title("Remove the stored API key?").
-				Description("This clears api_key in " + config.ConfigFilePath()).
-				Affirmative("Yes, log out").
-				Negative("Cancel").
-				Value(&confirmed),
-		),
-	).WithTheme(ui.HuhTheme()).Run()
-	if err != nil {
-		return fmt.Errorf("confirmation: %w", err)
+	ctx, cancel := context.WithTimeout(cmd.Context(), 20*time.Second)
+	defer cancel()
+
+	if hasOAuth {
+		revoked, err := auth.Logout(ctx, store)
+		if err != nil {
+			return fmt.Errorf("clearing OAuth session: %w", err)
+		}
+		appLogger.Info("auth_logout_oauth", "revoked", revoked)
+		if revoked {
+			fmt.Fprintln(out, ui.SuccessBanner("Signed out — OAuth session revoked and cleared"))
+		} else {
+			fmt.Fprintln(out, ui.SuccessBanner("Signed out — OAuth session cleared (server revocation best-effort)"))
+		}
 	}
 
-	if !confirmed {
-		fmt.Fprintln(out, ui.FaintStyle().Render("  Cancelled."))
-		return nil
+	if hasFileKey || authLogoutAPIKey {
+		if err := config.SetAPIKey(""); err != nil {
+			return err
+		}
+		appLogger.Info("auth_logout_apikey", "config_path", config.ConfigFilePath())
+		fmt.Fprintln(out, ui.SuccessBanner("Stored API key removed from "+config.ConfigFilePath()))
+	} else if hasOAuth && cfg.APIKey != "" {
+		fmt.Fprintln(out, ui.FaintStyle().Render(
+			"  Note: a config-file API key is still set; run 'truestamp auth logout --api-key' to remove it."))
 	}
 
-	if err := config.SetAPIKey(""); err != nil {
-		return err
-	}
-
-	appLogger.Info("auth_logout", "config_path", config.ConfigFilePath())
-	fmt.Fprintln(out, ui.SuccessBanner("Logged out — API key removed"))
+	auth.SetDefault(auth.Resolve(
+		auth.Credentials{APIKey: "", APIKeyExplicit: cfg.APIKeyExplicit}, store))
 	return nil
+}
+
+func logoutDescription(hasOAuth, clearsKey bool) string {
+	switch {
+	case hasOAuth && clearsKey:
+		return "Revoke the OAuth session and remove the stored API key."
+	case hasOAuth:
+		return "Revoke and clear the OAuth session."
+	default:
+		return "Clear the stored API key in " + config.ConfigFilePath() + "."
+	}
 }
 
 func runAuthStatus(cmd *cobra.Command, _ []string) error {
@@ -178,6 +310,7 @@ func runAuthStatus(cmd *cobra.Command, _ []string) error {
 	cfg := appConfig
 	apiURL := cfg.APIURL
 	checkURL := apiURL + "/users"
+	azr := auth.Default()
 
 	labelStyle := lipgloss.NewStyle().Foreground(ui.Label)
 
@@ -186,22 +319,38 @@ func runAuthStatus(cmd *cobra.Command, _ []string) error {
 		Row("Config File", config.ConfigFilePath()).
 		Row("API URL", apiURL).
 		Row("Check URL", checkURL).
-		Row("API Key", maskAPIKey(cfg.APIKey)).
-		Row("Team In Scope", teamInScope(cfg.Team))
+		Row("Auth Mode", authModeDisplay())
+
+	// OAuth session detail rows — only when OAuth is the ACTIVE credential,
+	// so the displayed scope/expiry always matches the Auth Mode (an
+	// explicit API key can override a still-stored session).
+	store := auth.NewStore(cfg.BaseURL)
+	if azr.Mode() == auth.ModeOAuth {
+		if sess, serr := store.Load(); serr == nil {
+			if sess.Scope != "" {
+				t = t.Row("Scopes", sess.Scope)
+			}
+			t = t.Row("Token Expiry", formatTokenExpiry(sess.Expiry))
+		}
+	}
+	if cfg.APIKey != "" {
+		t = t.Row("API Key", maskAPIKey(cfg.APIKey))
+	}
+	t = t.Row("Team In Scope", teamInScope(cfg.Team))
 
 	fmt.Fprintln(out, ui.HeaderBox("Truestamp Auth Status", "Validating with the API"))
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, t.String())
 
-	if cfg.APIKey == "" {
-		fmt.Fprintln(out, ui.FailureBanner("Not logged in"))
-		fmt.Fprintln(out, labelStyle.Render("    Run 'truestamp auth login' to store an API key."))
+	if azr.Mode() == auth.ModeNone {
+		fmt.Fprintln(out, ui.FailureBanner("Not authenticated"))
+		fmt.Fprintln(out, labelStyle.Render("    Run 'truestamp auth login' to sign in (or set TRUESTAMP_API_KEY)."))
 		return errSilentFail
 	}
 
 	ctx := cmd.Context()
 
-	userResult, err := checkAPIKey(ctx, apiURL, cfg.APIKey, cfg.Team)
+	userResult, err := checkAuth(ctx, azr, apiURL, cfg.Team)
 	if err != nil {
 		fmt.Fprintln(out, ui.FailureBanner("Could not reach the API"))
 		fmt.Fprintln(out, labelStyle.Render("    "+err.Error()))
@@ -210,11 +359,11 @@ func runAuthStatus(cmd *cobra.Command, _ []string) error {
 
 	switch {
 	case userResult.unauthorized:
-		fmt.Fprintln(out, ui.FailureBanner("API key rejected by the server"))
+		fmt.Fprintln(out, ui.FailureBanner("Credential rejected by the server"))
 		if userResult.message != "" {
 			fmt.Fprintln(out, labelStyle.Render("    "+userResult.message))
 		} else {
-			fmt.Fprintf(out, "    %s\n", labelStyle.Render(fmt.Sprintf("HTTP %d — run 'truestamp auth login' to replace the key.", userResult.httpStatus)))
+			fmt.Fprintf(out, "    %s\n", labelStyle.Render(fmt.Sprintf("HTTP %d — run 'truestamp auth login' to re-authenticate.", userResult.httpStatus)))
 		}
 		return errSilentFail
 
@@ -226,11 +375,10 @@ func runAuthStatus(cmd *cobra.Command, _ []string) error {
 		return errSilentFail
 	}
 
-	// User is authenticated. Resolve the team when one is configured, and
-	// surface an auth-style failure if the team is not accessible.
+	// Authenticated. Resolve the team when one is configured.
 	var teamResult *teamCheckResult
 	if cfg.Team != "" {
-		teamResult, err = fetchTeam(ctx, apiURL, cfg.APIKey, cfg.Team)
+		teamResult, err = fetchTeam(ctx, azr, apiURL, cfg.Team)
 		if err != nil {
 			fmt.Fprintln(out, ui.FailureBanner("Could not look up team"))
 			fmt.Fprintln(out, labelStyle.Render("    "+err.Error()))
@@ -244,12 +392,8 @@ func runAuthStatus(cmd *cobra.Command, _ []string) error {
 			fmt.Fprintln(out, labelStyle.Render(fmt.Sprintf("    HTTP %d — the team id may be wrong, or this user is not a member.", teamResult.httpStatus)))
 			return errSilentFail
 		}
-		// Best-effort role lookup. We've already proven the team is
-		// accessible; if the membership endpoint is degraded we still
-		// want to render the success banner with id+name. Soft-fail
-		// the role specifically.
 		role, _ := teams.GetMyRoleOnTeam(ctx, teams.Config{
-			APIURL: apiURL, APIKey: cfg.APIKey, Team: cfg.Team,
+			APIURL: apiURL, Team: cfg.Team,
 		}, cfg.Team)
 		teamResult.role = role
 	}
@@ -277,8 +421,6 @@ func formatUserIdentity(r *authCheckResult) string {
 }
 
 // formatTeam renders the resolved team context shown on success.
-// Retained for the pre-existing single-line consumers (none after the
-// refactor below, but kept callable so external tests don't break).
 func formatTeam(teamID string, r *teamCheckResult) string {
 	if teamID == "" {
 		return "personal team (no tenant header sent)"
@@ -293,11 +435,8 @@ func formatTeam(teamID string, r *teamCheckResult) string {
 	return fmt.Sprintf("%s  [%s]", label, teamID)
 }
 
-// formatTeamLines renders the team context as up-to-three lines for
-// the success-banner subblock: id, name (with optional `(personal)`
-// suffix), and role. Returns a single-line fallback when no team is
-// configured. Empty/unknown fields are skipped so the output stays
-// dense — we never render `Team Role: (unknown)`.
+// formatTeamLines renders the team context as up-to-three lines for the
+// success-banner subblock.
 func formatTeamLines(teamID string, r *teamCheckResult) []string {
 	if teamID == "" {
 		return []string{"Team: personal team (no tenant header sent)"}
@@ -316,6 +455,20 @@ func formatTeamLines(teamID string, r *teamCheckResult) []string {
 	return out
 }
 
+// formatTokenExpiry renders the access-token expiry for `auth status`.
+// Access tokens are short-lived (~1h) and auto-refreshed, so a past
+// timestamp is normal — annotate it so it doesn't read as a broken session.
+func formatTokenExpiry(exp time.Time) string {
+	switch {
+	case exp.IsZero():
+		return "(unknown) — auto-refreshes on next use"
+	case exp.Before(time.Now()):
+		return "expired — auto-refreshes on next use"
+	default:
+		return exp.Local().Format(time.RFC1123) + " (auto-refreshed)"
+	}
+}
+
 // authCheckResult summarizes the outcome of the /users probe.
 type authCheckResult struct {
 	ok           bool
@@ -327,12 +480,7 @@ type authCheckResult struct {
 	fullName     string
 }
 
-// teamCheckResult summarizes the outcome of the /teams/{id} probe. found
-// is true only on a 2xx response; 401/403/404 all return found=false.
-// role is populated by a parallel call to /memberships?filter[team_id]
-// — empty when the lookup failed or no membership exists. The empty-
-// string fallback degrades cleanly: the success banner still renders,
-// just without the role row.
+// teamCheckResult summarizes the outcome of the /teams/{id} probe.
 type teamCheckResult struct {
 	found      bool
 	httpStatus int
@@ -342,23 +490,23 @@ type teamCheckResult struct {
 	message    string
 }
 
-// checkAPIKey sends GET {apiURL}/users with the given bearer token and
-// interprets the response. Returns a non-nil error only for transport-level
-// failures (DNS, timeout, connection refused). All other outcomes — 2xx,
-// 4xx, 5xx — are reported in the result.
-func checkAPIKey(ctx context.Context, apiURL, apiKey, team string) (*authCheckResult, error) {
+// checkAuth sends GET {apiURL}/users authorized by azr and interprets the
+// response. Returns a non-nil error only for transport-level failures and
+// for a dead/unconfigured credential (azr.Authorize failing). All HTTP
+// outcomes — 2xx, 4xx, 5xx — are reported in the result.
+func checkAuth(ctx context.Context, azr auth.Authorizer, apiURL, team string) (*authCheckResult, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	// Keep the response small and sparse-fielded — an admin caller would
-	// otherwise see every user on the system here.
 	reqURL := apiURL + "/users?page[limit]=1&fields[user]=email,first_name,last_name,full_name"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Accept", "application/vnd.api+json")
-	req.Header.Set("Authorization", "Bearer "+apiKey)
+	if err := azr.Authorize(ctx, req); err != nil {
+		return nil, err
+	}
 	if team != "" {
 		req.Header.Set("tenant", team)
 	}
@@ -390,10 +538,8 @@ func checkAPIKey(ctx context.Context, apiURL, apiKey, team string) (*authCheckRe
 }
 
 // fetchTeam sends GET {apiURL}/teams/{id} and reports whether the caller
-// can see that team. A 401/403/404 is treated as "not accessible" (the
-// caller could not find it or lacks membership) rather than a transport
-// error. 5xx surfaces in message with found=false.
-func fetchTeam(ctx context.Context, apiURL, apiKey, teamID string) (*teamCheckResult, error) {
+// can see that team.
+func fetchTeam(ctx context.Context, azr auth.Authorizer, apiURL, teamID string) (*teamCheckResult, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -403,7 +549,9 @@ func fetchTeam(ctx context.Context, apiURL, apiKey, teamID string) (*teamCheckRe
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Accept", "application/vnd.api+json")
-	req.Header.Set("Authorization", "Bearer "+apiKey)
+	if err := azr.Authorize(ctx, req); err != nil {
+		return nil, err
+	}
 	req.Header.Set("tenant", teamID)
 
 	resp, err := httpclient.Do(req)
@@ -429,8 +577,7 @@ func fetchTeam(ctx context.Context, apiURL, apiKey, teamID string) (*teamCheckRe
 
 // extractUserIdentity pulls id, email, and a display name out of a
 // JSON:API response whose `data` may be either a single resource or an
-// array. Prefers the server-computed `full_name` attribute, then falls
-// back to `first_name last_name`. Missing fields return empty strings.
+// array.
 func extractUserIdentity(body []byte) (id, email, fullName string) {
 	first := firstJSONAPIResource(body)
 	if first == nil {
@@ -515,8 +662,7 @@ func extractAPIErrorMessage(body []byte) string {
 
 // teamInScope returns the tenant header value the CLI will send, or a
 // placeholder noting that the personal team will be used when no team has
-// been configured. The API assigns requests without a tenant to the
-// caller's personal team.
+// been configured.
 func teamInScope(team string) string {
 	if team == "" {
 		return "(personal team — set TRUESTAMP_TEAM or --team to override)"
@@ -534,11 +680,7 @@ func stringAttr(m map[string]any, key string) string {
 	return ""
 }
 
-// apiKeysURL derives the web app's API keys page from the API base URL by
-// keeping the scheme and host and replacing the path with /api-keys. A
-// default `https://www.truestamp.com/api/json` therefore maps to
-// `https://www.truestamp.com/api-keys`, and a local `http://localhost:4000/api/json`
-// maps to `http://localhost:4000/api-keys`.
+// apiKeysURL derives the web app's API keys page from the API base URL.
 func apiKeysURL(apiURL string) (string, error) {
 	u, err := url.Parse(apiURL)
 	if err != nil || u.Scheme == "" || u.Host == "" {

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/truestamp/truestamp-cli/internal/auth"
 	"github.com/truestamp/truestamp-cli/internal/httpclient"
 )
 
@@ -128,7 +129,7 @@ func TestCheckAPIKey(t *testing.T) {
 			}))
 			t.Cleanup(srv.Close)
 
-			res, err := checkAPIKey(context.Background(), srv.URL+"/api/json", "test-key", "")
+			res, err := checkAuth(context.Background(), auth.APIKeyAuthorizer("test-key"), srv.URL+"/api/json", "")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -215,7 +216,7 @@ func TestFetchTeam(t *testing.T) {
 			}))
 			t.Cleanup(srv.Close)
 
-			res, err := fetchTeam(context.Background(), srv.URL+"/api/json", "k", "team_42")
+			res, err := fetchTeam(context.Background(), auth.APIKeyAuthorizer("k"), srv.URL+"/api/json", "team_42")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -285,7 +286,7 @@ func TestCheckAPIKey_SendsTenantHeaderWhenTeamSet(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	if _, err := checkAPIKey(context.Background(), srv.URL+"/api/json", "k", "team_42"); err != nil {
+	if _, err := checkAuth(context.Background(), auth.APIKeyAuthorizer("k"), srv.URL+"/api/json", "team_42"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -293,7 +294,7 @@ func TestCheckAPIKey_SendsTenantHeaderWhenTeamSet(t *testing.T) {
 func TestCheckAPIKey_TransportErrorReturnsError(t *testing.T) {
 	httpclient.Init(100 * time.Millisecond)
 	// Point at a TCP port we're not listening on.
-	res, err := checkAPIKey(context.Background(), "http://127.0.0.1:1/api/json", "k", "")
+	res, err := checkAuth(context.Background(), auth.APIKeyAuthorizer("k"), "http://127.0.0.1:1/api/json", "")
 	if err == nil {
 		t.Fatalf("expected transport-level error, got result: %+v", res)
 	}

--- a/cmd/beacon.go
+++ b/cmd/beacon.go
@@ -43,7 +43,7 @@ Shared flags:
   --hash-only    Print only the hash field + newline (for shell substitution)
   -s, --silent   No output, exit code only
 
-Requires --api-key to be set (via flag, env, or config file).`,
+Requires authentication — run 'truestamp auth login', or set TRUESTAMP_API_KEY / --api-key for headless/CI use.`,
 	Args:          cobra.NoArgs,
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -103,18 +103,17 @@ func beaconSharedFlags(cmd *cobra.Command) (jsonOut, hashOnly, silent bool, err 
 // first printing a "not authenticated" banner to stderr (unless silent).
 func beaconConfig(cmd *cobra.Command) (beacons.Config, error) {
 	cfg := appConfig
-	if cfg.APIKey == "" {
+	if !authConfigured() {
 		silent, _ := cmd.Flags().GetBool("silent")
 		if !silent {
 			fmt.Fprintln(cmd.ErrOrStderr(), ui.FailureBanner("Not authenticated"))
 			fmt.Fprintln(cmd.ErrOrStderr(), ui.FaintStyle().Render(
-				"    Run 'truestamp auth login' to store an API key."))
+				"    Run 'truestamp auth login' to sign in (or set TRUESTAMP_API_KEY)."))
 		}
 		return beacons.Config{}, errSilentFail
 	}
 	return beacons.Config{
 		APIURL: cfg.APIURL,
-		APIKey: cfg.APIKey,
 		Team:   cfg.Team,
 	}, nil
 }
@@ -128,7 +127,7 @@ func beaconRenderError(cmd *cobra.Command, err error, silent bool) error {
 		if !silent {
 			fmt.Fprintln(cmd.ErrOrStderr(), ui.FailureBanner("Not authenticated"))
 			fmt.Fprintln(cmd.ErrOrStderr(), ui.FaintStyle().Render(
-				"    Run 'truestamp auth login' to store an API key."))
+				"    Run 'truestamp auth login' to sign in (or set TRUESTAMP_API_KEY)."))
 		}
 		return errSilentFail
 	}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -12,6 +12,7 @@ import (
 	lipgloss "charm.land/lipgloss/v2"
 	"charm.land/lipgloss/v2/table"
 	"github.com/spf13/cobra"
+	"github.com/truestamp/truestamp-cli/internal/auth"
 	"github.com/truestamp/truestamp-cli/internal/config"
 	"github.com/truestamp/truestamp-cli/internal/teams"
 	"github.com/truestamp/truestamp-cli/internal/ui"
@@ -76,6 +77,7 @@ func presentConfig(cfg *config.Config) {
 	general := ui.CompactTable().
 		StyleFunc(configStyleFunc).
 		Row("API URL", cfg.APIURL).
+		Row("Auth Mode", authModeDisplay()).
 		Row("API Key", maskAPIKey(cfg.APIKey)).
 		Row("Team", valueOrNotSet(cfg.Team))
 
@@ -84,7 +86,7 @@ func presentConfig(cfg *config.Config) {
 	// suppresses the extra rows in favor of a faint hint, so `config
 	// show` stays useful when offline. Capped to half the configured
 	// HTTP timeout so the command stays snappy.
-	if cfg.APIKey != "" && cfg.Team != "" {
+	if authConfigured() && cfg.Team != "" {
 		general = appendTeamDetailRows(general, cfg)
 	}
 
@@ -142,6 +144,18 @@ func configStyleFunc(row, col int) lipgloss.Style {
 	return lipgloss.NewStyle().Foreground(ui.Value)
 }
 
+// authModeDisplay renders the active credential mode for `config show`.
+func authModeDisplay() string {
+	switch auth.Default().Mode() {
+	case auth.ModeOAuth:
+		return "OAuth (browser sign-in)"
+	case auth.ModeAPIKey:
+		return "API key"
+	default:
+		return "none — run 'truestamp auth login'"
+	}
+}
+
 func maskAPIKey(key string) string {
 	if key == "" {
 		return "(not set)"
@@ -190,7 +204,7 @@ func appendTeamDetailRows(tbl *table.Table, cfg *config.Config) *table.Table {
 	ctx, cancel := context.WithTimeout(context.Background(), configTeamLookupTimeout(cfg))
 	defer cancel()
 
-	clientCfg := teams.Config{APIURL: cfg.APIURL, APIKey: cfg.APIKey, Team: cfg.Team}
+	clientCfg := teams.Config{APIURL: cfg.APIURL, Team: cfg.Team}
 
 	team, err := teams.GetTeam(ctx, clientCfg, cfg.Team)
 	if err != nil {

--- a/cmd/console.go
+++ b/cmd/console.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/truestamp/truestamp-cli/internal/auth"
 	"github.com/truestamp/truestamp-cli/internal/config"
 	"github.com/truestamp/truestamp-cli/internal/console"
 	"github.com/truestamp/truestamp-cli/internal/teams"
@@ -26,8 +27,9 @@ var consoleCmd = &cobra.Command{
   • New Item   — create a timestamped item and watch its lifecycle live
   • Connection — diagnostics, scope, push counts, log file path
 
-Authentication uses your existing API key (same key used by all other
-truestamp commands). The wire protocol is Phoenix Channels' V2 JSON-array
+Authentication uses your active Truestamp session — an OAuth sign-in (run
+'truestamp auth login') or, for headless/CI use, an API key via
+TRUESTAMP_API_KEY. The wire protocol is Phoenix Channels' V2 JSON-array
 format and is hand-writable from websocat for scripting.
 
 Transport diagnostics (read EOFs, dial-attempt failures during reconnect,
@@ -47,8 +49,8 @@ func init() {
 }
 
 func runConsole(cmd *cobra.Command, _ []string) error {
-	if appConfig.APIKey == "" {
-		return fmt.Errorf("no API key configured — run `truestamp auth login` or set TRUESTAMP_API_KEY")
+	if !authConfigured() {
+		return fmt.Errorf("not authenticated — run `truestamp auth login` (or set TRUESTAMP_API_KEY)")
 	}
 
 	// Resolve the WebSocket URL. Default comes from base_url via Config;
@@ -91,7 +93,7 @@ func runConsole(cmd *cobra.Command, _ []string) error {
 
 	return console.Run(cmd.Context(), console.Options{
 		WSURL:          wsURL,
-		APIKey:         appConfig.APIKey,
+		Authorizer:     auth.Default(),
 		APIURL:         appConfig.APIURL,
 		ActiveTeamID:   activeTeamID,
 		Logger:         appLogger,
@@ -112,7 +114,6 @@ func promptForFirstRunTeam(ctx context.Context) (string, error) {
 
 	cfg := teams.Config{
 		APIURL: appConfig.APIURL,
-		APIKey: appConfig.APIKey,
 	}
 	memberships, err := teams.ListMyMemberships(pctx, cfg)
 	if err != nil {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -66,7 +66,7 @@ Input methods (resolved in priority order):
 Flags override values from file/auto-hash, enabling combinations like:
   truestamp create report.pdf -n "Q1 Report" -v public -t finance
 
-Requires --api-key to be set (via flag, env, or config file).`,
+Requires authentication — run 'truestamp auth login', or set TRUESTAMP_API_KEY / --api-key for headless/CI use.`,
 	Args:          cobra.MaximumNArgs(1),
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -83,8 +83,8 @@ Requires --api-key to be set (via flag, env, or config file).`,
 		}
 
 		cfg := appConfig
-		if cfg.APIKey == "" {
-			return fmt.Errorf("API key required (use --api-key or set TRUESTAMP_API_KEY)")
+		if !authConfigured() {
+			return fmt.Errorf("not authenticated — run `truestamp auth login`, or set TRUESTAMP_API_KEY / --api-key for headless use")
 		}
 
 		jsonOutput, _ := cmd.Flags().GetBool("json")
@@ -127,7 +127,7 @@ Requires --api-key to be set (via flag, env, or config file).`,
 			"tag_count", len(tags),
 			"claim_keys", len(claims),
 		)
-		resp, err := items.CreateItemCtx(cmd.Context(), cfg.APIURL, cfg.APIKey, cfg.Team, claims, visibility, tags)
+		resp, err := items.CreateItemCtx(cmd.Context(), cfg.APIURL, cfg.Team, claims, visibility, tags)
 		if err != nil {
 			appLogger.Error("create_failed", "err", err.Error())
 			return err

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -59,10 +59,12 @@ func TestCLI_Create_Help_ShowsAllFlags(t *testing.T) {
 
 func TestCLI_Create_NoAPIKey_Error(t *testing.T) {
 	cmd := exec.Command(binaryPath, "create", "-n", "Test", "--hash", validSHA256Hex)
-	cmd.Env = append(os.Environ(), "TRUESTAMP_API_KEY=", "TRUESTAMP_API_URL=http://localhost:0")
+	// Empty API key + a loopback base_url with no stored OAuth session ⇒
+	// no credential ⇒ the "not authenticated" guard fires.
+	cmd.Env = append(os.Environ(), "TRUESTAMP_API_KEY=", "TRUESTAMP_BASE_URL=http://127.0.0.1:0")
 	out, _ := cmd.CombinedOutput()
-	if !containsString(string(out), "API key required") {
-		t.Errorf("expected API key error, got: %s", out)
+	if !containsString(string(out), "not authenticated") {
+		t.Errorf("expected not-authenticated error, got: %s", out)
 	}
 }
 

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -93,7 +93,7 @@ Examples:
   truestamp download --type entropy_stellar 019cf813-99b8-730a-84f1-5a711a9c355e
   truestamp download -o proof.json 01KNN33GX5E470CB9TRWAYF9DD
 
-Requires --api-key to be set (via flag, env, or config file).
+Requires authentication — run 'truestamp auth login', or set TRUESTAMP_API_KEY / --api-key for headless/CI use.
 
 Exit code 0 on success, 1 on any error (validation failure, network
 error, missing API key, server rejection, or failure to write the
@@ -109,8 +109,8 @@ output file).`,
 		cfg := appConfig
 		id := args[0]
 
-		if cfg.APIKey == "" {
-			return fmt.Errorf("API key required (use --api-key or set TRUESTAMP_API_KEY)")
+		if !authConfigured() {
+			return fmt.Errorf("not authenticated — run `truestamp auth login`, or set TRUESTAMP_API_KEY / --api-key for headless use")
 		}
 
 		format, _ := cmd.Flags().GetString("format")
@@ -159,7 +159,7 @@ output file).`,
 		// Wire-send typeFlag verbatim. Beacon is a first-class server type
 		// now (returns t=11), not a client-side alias.
 		appLogger.Info("download_request", "id", id, "type", typeFlag, "format", format)
-		data, err := proof.GenerateCtx(cmd.Context(), cfg.APIURL, cfg.APIKey, cfg.Team, id, typeFlag, format)
+		data, err := proof.GenerateCtx(cmd.Context(), cfg.APIURL, cfg.Team, id, typeFlag, format)
 		if err != nil {
 			appLogger.Error("download_failed", "id", id, "type", typeFlag, "err", err.Error())
 			return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/truestamp/truestamp-cli/internal/auth"
 	"github.com/truestamp/truestamp-cli/internal/config"
 	"github.com/truestamp/truestamp-cli/internal/httpclient"
 	"github.com/truestamp/truestamp-cli/internal/install"
@@ -86,6 +87,19 @@ var rootCmd = &cobra.Command{
 		appConfig = cfg
 		httpclient.Init(cfg.Timeout())
 		httpclient.SetUserAgent(version.Version)
+
+		// Resolve the active credential once (explicit API key → OAuth
+		// session → config-file API key → none) and install it as the
+		// process-wide Authorizer that every HTTP call site and the
+		// console WebSocket draw from.
+		auth.SetDefault(auth.Resolve(
+			auth.Credentials{APIKey: cfg.APIKey, APIKeyExplicit: cfg.APIKeyExplicit},
+			auth.NewStore(cfg.BaseURL),
+		))
+		// Layer reactive 401 → refresh → retry-once on the shared client so
+		// every authenticated HTTP call recovers from a server-rejected
+		// access token without surfacing a spurious auth failure.
+		httpclient.SetTransport(auth.NewRetryTransport(nil))
 
 		// Build the process-wide logger once config has been resolved
 		// so user-supplied --log-file / TRUESTAMP_LOGGING_FILE / TOML
@@ -167,6 +181,12 @@ func LoggerFrom(ctx context.Context) *slog.Logger {
 	}
 	return logging.Discard()
 }
+
+// authConfigured reports whether any credential — an OAuth session or an
+// API key — is active for this invocation. Subcommands gate on it before
+// making authenticated calls so the user gets a clear "log in" message
+// instead of a raw 401.
+func authConfigured() bool { return auth.Default().Mode() != auth.ModeNone }
 
 // maybeEmitUpgradeNotice runs after any successful subcommand and may
 // write a one-line "upgrade available" notice to stderr. It is a no-op

--- a/cmd/team.go
+++ b/cmd/team.go
@@ -45,18 +45,17 @@ the right URL automatically.`,
 // first printing a "not authenticated" banner to stderr (unless silent).
 func teamConfig(cmd *cobra.Command) (teams.Config, error) {
 	cfg := appConfig
-	if cfg.APIKey == "" {
+	if !authConfigured() {
 		silent, _ := cmd.Flags().GetBool("silent")
 		if !silent {
 			fmt.Fprintln(cmd.ErrOrStderr(), ui.FailureBanner("Not authenticated"))
 			fmt.Fprintln(cmd.ErrOrStderr(), ui.FaintStyle().Render(
-				"    Run 'truestamp auth login' to store an API key."))
+				"    Run 'truestamp auth login' to sign in (or set TRUESTAMP_API_KEY)."))
 		}
 		return teams.Config{}, errSilentFail
 	}
 	return teams.Config{
 		APIURL: cfg.APIURL,
-		APIKey: cfg.APIKey,
 		Team:   cfg.Team,
 	}, nil
 }
@@ -70,7 +69,7 @@ func teamRenderError(cmd *cobra.Command, err error, silent bool) error {
 		if !silent {
 			fmt.Fprintln(cmd.ErrOrStderr(), ui.FailureBanner("Not authenticated"))
 			fmt.Fprintln(cmd.ErrOrStderr(), ui.FaintStyle().Render(
-				"    The API key was rejected. Run 'truestamp auth login' to store a fresh key."))
+				"    Your credential was rejected. Run 'truestamp auth login' to sign in again."))
 		}
 		return errSilentFail
 	}
@@ -78,7 +77,7 @@ func teamRenderError(cmd *cobra.Command, err error, silent bool) error {
 		if !silent {
 			fmt.Fprintln(cmd.ErrOrStderr(), ui.FailureBanner("Access denied"))
 			fmt.Fprintln(cmd.ErrOrStderr(), ui.FaintStyle().Render(
-				"    Your API key is valid, but you do not have access to that team."))
+				"    You're authenticated, but you do not have access to that team."))
 			fmt.Fprintln(cmd.ErrOrStderr(), ui.FaintStyle().Render(
 				"    Run 'truestamp team list' to see the teams you are a member of."))
 		}

--- a/cmd/team_list.go
+++ b/cmd/team_list.go
@@ -17,10 +17,9 @@ import (
 
 var teamListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "Show all teams the API key has membership in",
-	Long: `List the teams the current API key is a member of, with the user's role
-in each. The active team (the one stored under 'team' in config.toml)
-is marked with a star.
+	Short: "Show all teams you're a member of",
+	Long: `List the teams you're a member of, with your role in each. The active
+team (the one stored under 'team' in config.toml) is marked with a star.
 
 Examples:
   truestamp team list
@@ -111,7 +110,7 @@ func renderEmptyTeamList(w io.Writer, apiURL string) {
 	body := []string{
 		header,
 		"",
-		"  " + ui.FaintStyle().Render("No teams found for this API key."),
+		"  " + ui.FaintStyle().Render("No teams found for your account."),
 	}
 	if url := ui.TeamCreateURL(apiURL); url != "" {
 		body = append(body,

--- a/cmd/team_set.go
+++ b/cmd/team_set.go
@@ -92,7 +92,7 @@ func runTeamSet(cmd *cobra.Command, args []string) error {
 	// valid to use as the tenant header on these reads. Soft-fail
 	// the role lookup so a degraded server-side response doesn't
 	// suppress the success confirmation.
-	postSwitchCfg := teams.Config{APIURL: cfg.APIURL, APIKey: cfg.APIKey, Team: targetID}
+	postSwitchCfg := teams.Config{APIURL: cfg.APIURL, Team: targetID}
 	team, err := teams.GetTeam(cmd.Context(), postSwitchCfg, targetID)
 	if err != nil {
 		fmt.Fprintln(cmd.OutOrStdout(),

--- a/cmd/testdata/golden/help_root.txt
+++ b/cmd/testdata/golden/help_root.txt
@@ -7,7 +7,7 @@ Usage:
   truestamp [command]
 
 Available Commands:
-  auth        Manage Truestamp API authentication
+  auth        Manage Truestamp authentication
   beacon      Inspect Truestamp block beacons
   completion  Generate the autocompletion script for the specified shell
   config      Manage CLI configuration

--- a/cmd/testdata/golden/help_verify.txt
+++ b/cmd/testdata/golden/help_verify.txt
@@ -23,7 +23,8 @@ plain block proof (both verify on their own, but only --type beacon
 catches the swap).
 
 Use --remote to delegate verification to the Truestamp server API instead
-of performing local computation. Requires --api-key to be set.
+of performing local computation. Requires authentication — run
+'truestamp auth login', or set TRUESTAMP_API_KEY / --api-key for headless/CI use.
 
 Exit code 0 on success, 1 on verification failure.
 

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -52,7 +52,8 @@ plain block proof (both verify on their own, but only --type beacon
 catches the swap).
 
 Use --remote to delegate verification to the Truestamp server API instead
-of performing local computation. Requires --api-key to be set.
+of performing local computation. Requires authentication — run
+'truestamp auth login', or set TRUESTAMP_API_KEY / --api-key for headless/CI use.
 
 Exit code 0 on success, 1 on verification failure.`,
 	Args:          cobra.MaximumNArgs(1),
@@ -137,8 +138,8 @@ Exit code 0 on success, 1 on verification failure.`,
 			if cfg.Verify.SkipExternal || cfg.Verify.SkipSignatures {
 				return fmt.Errorf("--skip-external and --skip-signatures cannot be used with --remote (server always runs full verification)")
 			}
-			if cfg.APIKey == "" {
-				return fmt.Errorf("API key required for --remote verification (use --api-key or set TRUESTAMP_API_KEY)")
+			if !authConfigured() {
+				return fmt.Errorf("not authenticated — --remote verification needs `truestamp auth login`, or TRUESTAMP_API_KEY / --api-key for headless use")
 			}
 
 			// Remote verification needs a file on disk. For non-file
@@ -156,9 +157,8 @@ Exit code 0 on success, 1 on verification failure.`,
 				defer os.Remove(tmpPath)
 			}
 
-			report, err = verify.RunRemote(sourceFile, verify.RemoteOptions{
+			report, err = verify.RunRemoteCtx(cmd.Context(), sourceFile, verify.RemoteOptions{
 				APIURL:              cfg.APIURL,
-				APIKey:              cfg.APIKey,
 				Team:                cfg.Team,
 				ExpectedHash:        hashFlag,
 				ExpectedSubjectType: typeFlag,

--- a/docs/engineering/console.md
+++ b/docs/engineering/console.md
@@ -13,19 +13,22 @@ live in [truestamp-v2/docs/console_channel.md](https://github.com/truestamp/true
 ## Anatomy
 
 ```
-cmd/console.go                       Cobra registration + flag plumbing
+cmd/console.go                       Cobra registration + flag plumbing; passes auth.Default() as Options.Authorizer
 internal/console/                    The TUI
-  app.go                             Bubble Tea root model, header/footer, pane switching
+  app.go                             Bubble Tea root model, header/footer, pane switching; maps Options.Authorizer → wschannel OAuth/API-key options
   monitor.go                         Monitor pane: stream toggles + scrollable waterfall
   newitem.go                         New Item pane: form + lifecycle card
   connection.go                      Connection pane: scope, push counts, reconnect summary, log path
-  messages.go                        tea.Msg types + waitForPush bridge
-internal/wschannel/                  Phoenix Channel V2 client (homegrown, ~600 LOC)
-  client.go                          Connection lifecycle, multi-topic, reconnect, redaction
+  connerror.go                       Dial-error classifier; a dead/absent OAuth session routes to the "re-authenticate" hint
+  messages.go                        tea.Msg types + waitForPush bridge; routes tokenRefreshingMsg / authFailedMsg
+internal/auth/                       OAuth 2.1 client + Authorizer abstraction (see CLAUDE.md "Authentication")
+internal/wschannel/                  Phoenix Channel V2 client (homegrown)
+  client.go                          Connection lifecycle, multi-topic, reconnect, OAuth Bearer auth + token_expired recovery, redaction
   codec.go                           Frame encoder/decoder
-  redact_test.go                     api_key never leaks
+  redact_test.go                     api_key / Bearer token never leaks
   smoke_test.go                      Opt-in live-server tests (build tag: smoke)
-internal/logging/logging.go          slog + lumberjack file logger
+internal/redact/redact.go            Single redaction source (api_key, Bearer, OAuth tokens/code/verifier)
+internal/logging/logging.go          slog + lumberjack file logger (redacts via internal/redact)
 ```
 
 The **server** documentation in `truestamp-v2/docs/console_channel.md`
@@ -63,10 +66,64 @@ context-sensitive key hints.
 
 ## WebSocket client (`internal/wschannel`)
 
-Homegrown ~600-line Phoenix Channels V2 client. The wire format is so
-small a third-party client (e.g. `nshafer/phx`) is more code than the
-problem; controlling reconnect/heartbeat behavior precisely matters
+Homegrown Phoenix Channels V2 client (`client.go` ~1k LOC). The wire
+format is so small a third-party client (e.g. `nshafer/phx`) is more code
+than the problem; controlling reconnect/heartbeat behavior — and the
+OAuth `?access_token=` upgrade + `token_expired` recovery below — precisely matters
 for a long-running TUI.
+
+### Authentication (OAuth Bearer + `token_expired` recovery)
+
+The console draws its credential from the process-wide `auth.Authorizer`
+(`cmd/console.go` passes `auth.Default()` as `Options.Authorizer`;
+`internal/console/app.go` maps it onto the wschannel options). Two modes:
+
+- **OAuth** (`Authorizer.Mode() == ModeOAuth`): the access token is sent
+  as the `?access_token=<jwt>` query param on the WebSocket **upgrade**
+  (a Phoenix upgrade can't expose the `Authorization` header to the
+  socket's `connect/3` — `:x_headers` only captures `x-*` headers — so
+  the token rides the query like `?api_key=` does). The client wires
+  `Options.BearerToken = Authorizer.BearerToken` and pulls a *fresh*
+  token on every (re)dial, so a reconnect after a token refresh
+  automatically carries the new credential.
+- **API key** (`ModeAPIKey`): unchanged — the key is resolved once and
+  sent as the `?api_key=` query param to the server's `connect/3`
+  callback.
+
+OAuth access tokens are short-lived; the token is validated at *connect*
+(not at channel join), so re-authenticating means re-dialling the whole
+socket. The recovery flow on a server `token_expired` push:
+
+1. Emit a synthetic `token_refreshing` push (the TUI shows a transient
+   "refreshing session" hint via `tokenRefreshingMsg`).
+2. Call `Options.ForceRefresh` (the authorizer's `ForceRefresh`) **now**,
+   so the upcoming reconnect dials with a genuinely new access token
+   rather than re-presenting the just-rejected one (which would loop
+   under client/server clock skew).
+3. `dropConn` → the normal reconnect-with-backoff path re-dials with the
+   refreshed token and re-joins every topic.
+
+**Fatal dead-session stop**: if the forced refresh fails because the
+refresh token is expired/revoked/reused (`invalid_grant` →
+`auth.ErrSessionExpired`), `Options.FatalDialErr` classifies it as
+permanently fatal. The client sets `authDead`, stops retrying, and emits
+`auth_failed` (`authFailedMsg`) instead of looping forever re-presenting a
+locally-"valid" but server-rejected token. The TUI surfaces a re-login
+prompt; `connerror.go` also maps `ErrSessionExpired` / `ErrNoCredentials`
+on the dial to the "re-authenticate" hint rather than a network error.
+
+**In-band keep-alive** (`keepAliveLoop` + `inBandRefresh`). When the caller
+wires `wschannel.Options.AccessTokenExpiry` (the console does, from
+`auth.Authorizer.AccessTokenExpiry`), a background loop polls and, ~60s
+before the access token expires, force-refreshes it and pushes
+`token.refresh {"access_token": <jwt>}` on `console:lobby` over the *live*
+socket. The server re-validates the new token and reschedules its
+disconnect timer (`{:ok, %{exp}}`), so a long session re-authenticates
+**without** dropping/reconnecting and `token_expired` never fires. On any
+failure — dead session (`{:error, invalid_token}` → stop + re-login),
+rejected token, or a delivery hiccup — it falls back to the reactive
+`token_expired` → re-dial path above. The `token_expired` path remains the
+safety net for the asleep-past-expiry case.
 
 ### What it guarantees
 
@@ -104,17 +161,24 @@ for a long-running TUI.
   if the consumer falls behind, frames are dropped (logged at
   `warn`) rather than blocking the reader (which would also block
   the heartbeat).
-- **API-key redaction**. The websocket library's dial errors echo the
-  upgrade URL verbatim, including `api_key=…`. `wschannel` redacts
-  every error before returning to the caller AND before logging via
-  the slog logger. The `truestamp_…` token can never reach the UI,
-  the log file, or any stderr the host process owns.
+- **Secret redaction**. The websocket library's dial errors echo the
+  upgrade URL (and, in OAuth mode, the `Authorization` header) verbatim,
+  including `api_key=…` and `Bearer <jwt>`. `wschannel` flows every
+  error through `internal/redact` before returning to the caller AND
+  before logging via the slog logger. Neither the `truestamp_…` key nor
+  an OAuth access/refresh token can reach the UI, the log file, or any
+  stderr the host process owns. `redact` is the single source of truth
+  (shared with `internal/logging`); see CLAUDE.md "Authentication" for
+  the full pattern set.
 
 ### What it does NOT do
 
-- No automatic reauthentication on a `4401` close. If the server
-  rejects the API key, reconnect attempts will keep failing — fix
-  the key, restart the CLI.
+- **OAuth**: token *expiry* is recovered automatically (see
+  Authentication above — `token_expired` → force-refresh → re-dial →
+  re-join). A genuinely dead session (refresh token revoked/expired)
+  stops reconnect and prompts re-login rather than looping.
+- **API key**: no automatic reauthentication. If the server rejects the
+  key, reconnect attempts keep failing — fix the key, restart the CLI.
 - No exponential backoff jitter. Fine at single-user scale; would
   matter at thousand-client thundering-herd scale.
 - No subscription persistence across CLI restarts. Each launch
@@ -122,16 +186,20 @@ for a long-running TUI.
 
 ### Sentinel push events
 
-`internal/wschannel` exports two synthetic event-name constants used
-by application code to special-case reconnect lifecycle:
+`internal/wschannel` exports synthetic event-name constants used by
+application code to special-case reconnect and OAuth lifecycle:
 
-| Constant                      | Wire value      | When                                                                |
-| ----------------------------- | --------------- | ------------------------------------------------------------------- |
-| `wschannel.ReconnectingEvent` | `"reconnecting"`| Emitted before each dial attempt during a reconnect cycle.          |
-| `wschannel.ReconnectedEvent`  | `"rejoined"`    | Emitted per topic after a successful redial+rejoin.                 |
+| Constant                      | Wire value         | When                                                                |
+| ----------------------------- | ------------------ | ------------------------------------------------------------------- |
+| `wschannel.ReconnectingEvent` | `"reconnecting"`   | Emitted before each dial attempt during a reconnect cycle.          |
+| `wschannel.ReconnectedEvent`  | `"rejoined"`       | Emitted per topic after a successful redial+rejoin.                 |
+| `wschannel.TokenRefreshEvent` | `"token_refreshing"`| Emitted on a server `token_expired` push while the client force-refreshes the OAuth token and re-dials. |
+| `wschannel.AuthFailedEvent`   | `"auth_failed"`    | Emitted when the OAuth session is permanently dead (`invalid_grant`); reconnect stops and the user must re-authenticate. |
 
-Neither is sent by the server; both are synthetic, injected by the
-client into `Pushes()` for the application to observe.
+None are sent by the server; all are synthetic, injected by the client
+into `Pushes()` for the application to observe. (The server's own
+`token_expired` push is the *input* that triggers `token_refreshing` /
+`auth_failed`.)
 
 ## Logging (`internal/logging`)
 
@@ -314,10 +382,12 @@ task test          # everything
 task precommit     # full gate (gofmt + vet + staticcheck + gosec + tests + build)
 ```
 
-`internal/wschannel/redact_test.go` is the security-critical test:
-asserts the API key never leaks into logs OR into errors returned
-to callers, even when the underlying websocket library echoes the
-upgrade URL verbatim.
+`internal/wschannel/redact_test.go` (plus `internal/redact/redact_test.go`,
+the source-of-truth redactor it relies on) is the security-critical test:
+asserts that neither the API key nor an OAuth access/refresh token leaks
+into logs OR into errors returned to callers, even when the underlying
+websocket library echoes the upgrade URL or `Authorization` header
+verbatim.
 
 ### Live smoke tests (gated behind `smoke` build tag)
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.2.0
 	github.com/catppuccin/go v0.3.0
 	github.com/charmbracelet/colorprofile v0.4.3
+	github.com/cli/browser v1.3.0
 	github.com/coder/websocket v1.8.15
 	github.com/fxamacker/cbor/v2 v2.9.2
 	github.com/gofrs/uuid/v5 v5.4.0
@@ -24,8 +25,10 @@ require (
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
+	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/crypto v0.53.0
 	golang.org/x/mod v0.37.0
+	golang.org/x/oauth2 v0.36.0
 	golang.org/x/term v0.44.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
@@ -45,11 +48,13 @@ require (
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
+	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.1.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
+	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kcalvinalvin/anet v0.0.0-20251112173137-d8ddc1f6dbee // indirect
 	github.com/knadh/koanf/maps v0.1.2 // indirect
@@ -61,7 +66,6 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sync v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/charmbracelet/x/windows v0.2.2 h1:IofanmuvaxnKHuV04sC0eBy/smG6kIKrWG2
 github.com/charmbracelet/x/windows v0.2.2/go.mod h1:/8XtdKZzedat74NQFn0NGlGL4soHB0YQZrETF96h75k=
 github.com/charmbracelet/x/xpty v0.1.3 h1:eGSitii4suhzrISYH50ZfufV3v085BXQwIytcOdFSsw=
 github.com/charmbracelet/x/xpty v0.1.3/go.mod h1:poPYpWuLDBFCKmKLDnhBp51ATa0ooD8FhypRwEFtH3Y=
+github.com/cli/browser v1.3.0 h1:LejqCrpWr+1pRqmEPDGnTZOjsMe7sehifLynZJuqJpo=
+github.com/cli/browser v1.3.0/go.mod h1:HH8s+fOAxjhQoBUAsKuPCbqUuxZDhQ2/aD+SzsEfBTk=
 github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSEFgwIwO+UVM8=
 github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3JhNl3dSqnGhOoSD/o0=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
@@ -59,6 +61,8 @@ github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6p
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
+github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
+github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -74,6 +78,8 @@ github.com/fxamacker/cbor/v2 v2.9.2 h1:X4Ksno9+x3cz0TZv69ec1hxP/+tymuR8PXQJyDwfh
 github.com/fxamacker/cbor/v2 v2.9.2/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/gofrs/uuid/v5 v5.4.0 h1:EfbpCTjqMuGyq5ZJwxqzn3Cbr2d0rUZU7v5ycAk/e/0=
 github.com/gofrs/uuid/v5 v5.4.0/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
 github.com/gowebpki/jcs v1.0.1 h1:Qjzg8EOkrOTuWP7DqQ1FbYtcpEbeTzUoTN9bptp8FOU=
@@ -124,6 +130,8 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
@@ -131,6 +139,8 @@ github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
+github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
+github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
@@ -138,6 +148,8 @@ golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
 golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
 golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2019-2026 Truestamp, Inc.
+// SPDX-License-Identifier: MIT
+
+// Package auth is the CLI's authentication core. It implements an
+// OAuth 2.1 client (browser-based loopback Authorization Code + PKCE with
+// rotating refresh tokens) and unifies it with the legacy long-lived API
+// key behind a single [Authorizer] abstraction.
+//
+// Authentication is OAuth-first, API-key-second. The resolution order
+// (see [Resolve]) is:
+//
+//  1. an explicitly-provided API key (--api-key flag or TRUESTAMP_API_KEY
+//     env) — wins outright so CI/headless callers are deterministic;
+//  2. a stored OAuth session (access token, auto-refreshed via the
+//     rotating refresh token);
+//  3. an API key from the config file;
+//  4. otherwise unauthenticated.
+//
+// Both an OAuth access token and an API key are presented to the server as
+// `Authorization: Bearer <value>` on the JSON API; the server accepts
+// either. The console WebSocket differs: OAuth uses the Bearer request
+// header on the upgrade, while an API key uses the `?api_key=` query
+// param — callers branch on [Authorizer.Mode] for that.
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// ClientID is the fixed, public OAuth client_id for the Truestamp CLI. It
+// is a public client (PKCE is the per-flow secret), so embedding it in the
+// binary is standard and safe — the same convention gh/gcloud/stripe use.
+// The server seeds this exact id via an idempotent boot-upsert across
+// dev/staging/prod, so a single constant is correct for every environment;
+// only the issuer/endpoints vary, and those come from discovery.
+const ClientID = "019ef661-6737-71ec-abd0-ac8f4684ce45"
+
+// Scopes is the set requested at login. It deliberately excludes the
+// mcp:* scopes (the CLI does not call /mcp); requesting an mcp scope is
+// rejected at /oauth/authorize. api:* covers JSON:API + GraphQL,
+// console:* covers the WebSocket console.
+var Scopes = []string{"api:read", "api:write", "console:read", "console:write"}
+
+// callbackPath is the loopback redirect path. The full redirect_uri
+// (`http://127.0.0.1:<port>/callback`) must byte-for-byte match a
+// redirect_uri registered on the server-side client, because the
+// authorization server does exact matching (no RFC 8252 port flexibility).
+const callbackPath = "/callback"
+
+// loopbackPorts are the fixed ports the CLI binds for the callback, in
+// preference order. Both are pre-registered on the server client. The CLI
+// tries them in turn and errors clearly if both are busy rather than
+// silently using an unregistered ephemeral port that the server would
+// reject.
+var loopbackPorts = []int{8976, 8765}
+
+// ErrNoCredentials is returned by a no-credentials [Authorizer] when a
+// bearer token is requested (e.g. by the WebSocket dialer, which cannot
+// proceed unauthenticated).
+var ErrNoCredentials = errors.New("not authenticated — run `truestamp auth login` (or set TRUESTAMP_API_KEY)")
+
+// ErrSessionExpired is returned in OAuth mode when the refresh token is
+// expired, revoked, or reused (the server's `invalid_grant`). The session
+// is permanently dead; the user must re-authenticate.
+var ErrSessionExpired = errors.New("OAuth session expired or revoked — run `truestamp auth login`")
+
+// Mode identifies which credential an [Authorizer] carries.
+type Mode int
+
+const (
+	// ModeNone means no credential is configured.
+	ModeNone Mode = iota
+	// ModeAPIKey means a long-lived API key is in use.
+	ModeAPIKey
+	// ModeOAuth means a short-lived, auto-refreshing OAuth access token
+	// is in use.
+	ModeOAuth
+)
+
+// String renders the mode for status output.
+func (m Mode) String() string {
+	switch m {
+	case ModeAPIKey:
+		return "api_key"
+	case ModeOAuth:
+		return "oauth"
+	default:
+		return "none"
+	}
+}
+
+// Authorizer stamps outbound requests with the active credential and
+// reports which credential is in use. Obtain one via [Resolve]. All
+// methods are safe for concurrent use.
+type Authorizer interface {
+	// Authorize adds the Authorization header to req. In OAuth mode it
+	// transparently refreshes an expired access token first (returning a
+	// non-nil error if the session is dead). In no-credentials mode it is
+	// a no-op returning nil so genuinely-public requests still go out.
+	Authorize(ctx context.Context, req *http.Request) error
+
+	// BearerToken returns the raw credential string — a fresh OAuth access
+	// token (refreshed if needed) or the API key — for carriers that
+	// cannot take an *http.Request (the WebSocket dialer). Returns
+	// [ErrNoCredentials] in no-credentials mode.
+	BearerToken(ctx context.Context) (string, error)
+
+	// ForceRefresh proactively discards any cached credential and obtains a
+	// fresh one. In OAuth mode it runs the refresh grant unconditionally
+	// (used reactively when the server rejects a token the client still
+	// believes is valid — a 401 on the HTTP API, or a token_expired push on
+	// the WebSocket — to break the otherwise-possible "reuse the stale
+	// token" loop). It is a no-op for the API-key and no-credentials modes.
+	// Returns [ErrSessionExpired] when the refresh token is dead.
+	ForceRefresh(ctx context.Context) error
+
+	// AccessTokenExpiry reports when the current OAuth access token expires,
+	// so a long-lived carrier (the console WebSocket) can proactively
+	// refresh in-band before the server force-disconnects. Returns the zero
+	// time for the API-key and no-credentials modes (no expiry).
+	AccessTokenExpiry() time.Time
+
+	// Mode reports the active credential type.
+	Mode() Mode
+}
+
+// defaultAuthorizer is the process-wide Authorizer set once at startup by
+// cmd after config load, mirroring httpclient's package-global pattern so
+// the many existing call sites can authorize without threading an
+// Authorizer through every signature.
+var (
+	defaultMu         sync.RWMutex
+	defaultAuthorizer Authorizer = noneAuthorizer{}
+)
+
+// SetDefault installs the process-wide Authorizer. Pass nil to reset to
+// the no-credentials authorizer.
+func SetDefault(a Authorizer) {
+	defaultMu.Lock()
+	defer defaultMu.Unlock()
+	if a == nil {
+		a = noneAuthorizer{}
+	}
+	defaultAuthorizer = a
+}
+
+// Default returns the process-wide Authorizer (never nil).
+func Default() Authorizer {
+	defaultMu.RLock()
+	defer defaultMu.RUnlock()
+	return defaultAuthorizer
+}
+
+// AuthorizeRequest stamps req using the process-wide [Default] Authorizer.
+// This is the minimal-churn entry point for the existing HTTP call sites.
+func AuthorizeRequest(ctx context.Context, req *http.Request) error {
+	return Default().Authorize(ctx, req)
+}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,439 @@
+// Copyright (c) 2019-2026 Truestamp, Inc.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/zalando/go-keyring"
+)
+
+// fakeAS is an in-memory OAuth 2.1 authorization server for tests: RFC 8414
+// discovery, an authorize endpoint that 302s to the loopback redirect with
+// a code, a token endpoint enforcing S256 PKCE and rotating refresh tokens,
+// and a revoke endpoint.
+type fakeAS struct {
+	srv *httptest.Server
+
+	mu           sync.Mutex
+	challenges   map[string]string // code -> code_challenge
+	refresh      map[string]bool   // valid (unrotated) refresh tokens
+	revoked      map[string]bool
+	tokenCounter int
+}
+
+func newFakeAS(t *testing.T) *fakeAS {
+	t.Helper()
+	f := &fakeAS{
+		challenges: map[string]string{},
+		refresh:    map[string]bool{},
+		revoked:    map[string]bool{},
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc(discoveryPath, f.handleDiscovery)
+	mux.HandleFunc("/oauth/authorize", f.handleAuthorize)
+	mux.HandleFunc("/oauth/token", f.handleToken)
+	mux.HandleFunc("/oauth/revoke", f.handleRevoke)
+	f.srv = httptest.NewServer(mux)
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+func (f *fakeAS) origin() string { return f.srv.URL }
+
+func (f *fakeAS) handleDiscovery(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, map[string]any{
+		"issuer":                                f.srv.URL,
+		"authorization_endpoint":                f.srv.URL + "/oauth/authorize",
+		"token_endpoint":                        f.srv.URL + "/oauth/token",
+		"revocation_endpoint":                   f.srv.URL + "/oauth/revoke",
+		"registration_endpoint":                 f.srv.URL + "/oauth/register",
+		"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
+		"response_types_supported":              []string{"code"},
+		"code_challenge_methods_supported":      []string{"S256"},
+		"scopes_supported":                      []string{"api:read", "api:write", "console:read", "console:write"},
+		"token_endpoint_auth_methods_supported": []string{"none"},
+	})
+}
+
+func (f *fakeAS) handleAuthorize(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	redirectURI := q.Get("redirect_uri")
+	state := q.Get("state")
+	challenge := q.Get("code_challenge")
+	if q.Get("code_challenge_method") != "S256" || challenge == "" {
+		http.Error(w, "missing S256 challenge", http.StatusBadRequest)
+		return
+	}
+	code := fmt.Sprintf("code-%d", time.Now().UnixNano())
+	f.mu.Lock()
+	f.challenges[code] = challenge
+	f.mu.Unlock()
+	http.Redirect(w, r, redirectURI+"?code="+url.QueryEscape(code)+"&state="+url.QueryEscape(state), http.StatusFound)
+}
+
+func (f *fakeAS) handleToken(w http.ResponseWriter, r *http.Request) {
+	_ = r.ParseForm()
+	if r.PostForm.Get("client_id") != ClientID {
+		writeTokenError(w, "invalid_client")
+		return
+	}
+	switch r.PostForm.Get("grant_type") {
+	case "authorization_code":
+		code := r.PostForm.Get("code")
+		verifier := r.PostForm.Get("code_verifier")
+		f.mu.Lock()
+		challenge, ok := f.challenges[code]
+		delete(f.challenges, code)
+		f.mu.Unlock()
+		if !ok || s256(verifier) != challenge {
+			writeTokenError(w, "invalid_grant")
+			return
+		}
+		f.issueTokens(w, "api:read api:write console:read console:write")
+	case "refresh_token":
+		rt := r.PostForm.Get("refresh_token")
+		f.mu.Lock()
+		valid := f.refresh[rt] && !f.revoked[rt]
+		delete(f.refresh, rt) // single-use rotation
+		f.mu.Unlock()
+		if !valid {
+			writeTokenError(w, "invalid_grant")
+			return
+		}
+		f.issueTokens(w, "")
+	default:
+		writeTokenError(w, "unsupported_grant_type")
+	}
+}
+
+func (f *fakeAS) issueTokens(w http.ResponseWriter, scope string) {
+	f.mu.Lock()
+	f.tokenCounter++
+	n := f.tokenCounter
+	rt := fmt.Sprintf("refresh-%d", n)
+	f.refresh[rt] = true
+	f.mu.Unlock()
+	body := map[string]any{
+		"access_token":  fmt.Sprintf("access-%d", n),
+		"refresh_token": rt,
+		"token_type":    "Bearer",
+		"expires_in":    3600,
+	}
+	if scope != "" {
+		body["scope"] = scope
+	}
+	writeJSON(w, body)
+}
+
+func (f *fakeAS) handleRevoke(w http.ResponseWriter, r *http.Request) {
+	_ = r.ParseForm()
+	f.mu.Lock()
+	f.revoked[r.PostForm.Get("token")] = true
+	f.mu.Unlock()
+	w.WriteHeader(http.StatusOK)
+}
+
+func s256(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeTokenError(w http.ResponseWriter, code string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": code})
+}
+
+// useMockKeyring routes go-keyring through its in-memory mock for the test.
+func useMockKeyring(t *testing.T) {
+	t.Helper()
+	keyring.MockInit()
+}
+
+// browserOpener returns a LoginOptions.Open that plays the browser: it
+// follows the authorize URL through the 302 to the loopback callback.
+func browserOpener(t *testing.T) func(string) error {
+	t.Helper()
+	return func(authURL string) error {
+		go func() {
+			resp, err := http.Get(authURL) //nolint:gosec // test loopback
+			if err == nil {
+				_, _ = io.Copy(io.Discard, resp.Body)
+				_ = resp.Body.Close()
+			}
+		}()
+		return nil
+	}
+}
+
+func TestLoginAndRefreshRotation(t *testing.T) {
+	useMockKeyring(t)
+	as := newFakeAS(t)
+	store := NewStore(as.origin())
+
+	// Bind an ephemeral loopback port for the test instead of 8976/8765.
+	orig := loopbackPorts
+	loopbackPorts = []int{0}
+	defer func() { loopbackPorts = orig }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	sess, err := Login(ctx, as.origin(), store, LoginOptions{Open: browserOpener(t), Out: io.Discard})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if sess.AccessToken != "access-1" || sess.RefreshToken != "refresh-1" {
+		t.Fatalf("unexpected initial tokens: %+v", sess)
+	}
+	if !strings.Contains(sess.Scope, "console:read") {
+		t.Fatalf("scope not captured: %q", sess.Scope)
+	}
+
+	// Force the access token to be expired so the next use refreshes.
+	expired := *sess
+	expired.Expiry = time.Now().Add(-time.Minute)
+	if err := store.Save(expired); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	authz := Resolve(Credentials{}, store)
+	if authz.Mode() != ModeOAuth {
+		t.Fatalf("expected OAuth mode, got %v", authz.Mode())
+	}
+	tok, err := authz.BearerToken(ctx)
+	if err != nil {
+		t.Fatalf("BearerToken (refresh): %v", err)
+	}
+	if tok != "access-2" {
+		t.Fatalf("expected refreshed access token access-2, got %q", tok)
+	}
+
+	// The rotated refresh token must have been persisted.
+	reloaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if reloaded.RefreshToken != "refresh-2" {
+		t.Fatalf("rotated refresh token not persisted: %q", reloaded.RefreshToken)
+	}
+	if reloaded.AccessToken != "access-2" {
+		t.Fatalf("refreshed access token not persisted: %q", reloaded.AccessToken)
+	}
+}
+
+func TestResolvePrecedence(t *testing.T) {
+	useMockKeyring(t)
+	store := NewStore("https://example.test")
+
+	// Explicit API key wins even when an OAuth session exists.
+	if err := store.Save(Session{Issuer: "https://example.test", TokenURL: "https://example.test/oauth/token", RefreshToken: "rt", AccessToken: "at", Expiry: time.Now().Add(time.Hour)}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if got := Resolve(Credentials{APIKey: "k", APIKeyExplicit: true}, store).Mode(); got != ModeAPIKey {
+		t.Fatalf("explicit key should win, got %v", got)
+	}
+	// No explicit key → OAuth session used.
+	if got := Resolve(Credentials{APIKey: "k"}, store).Mode(); got != ModeOAuth {
+		t.Fatalf("oauth session should be used, got %v", got)
+	}
+	// No session → config-file key used.
+	emptyStore := NewStore("https://empty.test")
+	if got := Resolve(Credentials{APIKey: "k"}, emptyStore).Mode(); got != ModeAPIKey {
+		t.Fatalf("file key should be used, got %v", got)
+	}
+	// Nothing → none.
+	if got := Resolve(Credentials{}, emptyStore).Mode(); got != ModeNone {
+		t.Fatalf("expected none, got %v", got)
+	}
+}
+
+func TestAccessTokenExpiry(t *testing.T) {
+	useMockKeyring(t)
+	store := NewStore("https://exp.test")
+	exp := time.Now().Add(42 * time.Minute).Round(time.Second)
+	if err := store.Save(Session{
+		Issuer: "https://exp.test", TokenURL: "https://exp.test/oauth/token",
+		RefreshToken: "rt", AccessToken: "at", Expiry: exp,
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if got := Resolve(Credentials{}, store).AccessTokenExpiry(); !got.Equal(exp) {
+		t.Fatalf("oauth AccessTokenExpiry = %v, want %v", got, exp)
+	}
+	if got := APIKeyAuthorizer("k").AccessTokenExpiry(); !got.IsZero() {
+		t.Fatalf("api-key AccessTokenExpiry should be zero, got %v", got)
+	}
+}
+
+func TestApiKeyAuthorizeHeader(t *testing.T) {
+	a := apiKeyAuthorizer{key: "secret-key"}
+	req, _ := http.NewRequest(http.MethodGet, "https://example.test", nil)
+	if err := a.Authorize(context.Background(), req); err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer secret-key" {
+		t.Fatalf("unexpected header %q", got)
+	}
+}
+
+func TestStoreFileFallback(t *testing.T) {
+	// Force keychain failure so Save/Load use the 0600 file fallback.
+	keyring.MockInitWithError(fmt.Errorf("no keychain"))
+	t.Cleanup(func() { keyring.MockInit() })
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CACHE_HOME", tmp)
+
+	store := NewStore("http://localhost:4000")
+	sess := Session{Issuer: "http://localhost:4000", TokenURL: "http://localhost:4000/oauth/token", RefreshToken: "rt-file", AccessToken: "at-file", Expiry: time.Now().Add(time.Hour)}
+	if err := store.Save(sess); err != nil {
+		t.Fatalf("Save (file): %v", err)
+	}
+	got, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load (file): %v", err)
+	}
+	if got.RefreshToken != "rt-file" {
+		t.Fatalf("file round-trip failed: %+v", got)
+	}
+	if err := store.Clear(); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+	if _, err := store.Load(); err != ErrNoSession {
+		t.Fatalf("expected ErrNoSession after clear, got %v", err)
+	}
+}
+
+func TestDiscoveryValidate(t *testing.T) {
+	good := &Discovery{
+		Issuer:                        "http://localhost:4000",
+		AuthorizationEndpoint:         "http://localhost:4000/oauth/authorize",
+		TokenEndpoint:                 "http://localhost:4000/oauth/token",
+		CodeChallengeMethodsSupported: []string{"S256"},
+	}
+	if err := good.Validate("http://localhost:4000"); err != nil {
+		t.Fatalf("valid discovery rejected: %v", err)
+	}
+	noS256 := *good
+	noS256.CodeChallengeMethodsSupported = []string{"plain"}
+	if err := noS256.Validate("http://localhost:4000"); err == nil {
+		t.Fatal("expected rejection without S256")
+	}
+	wrongIssuer := *good
+	wrongIssuer.Issuer = "http://evil.test"
+	if err := wrongIssuer.Validate("http://localhost:4000"); err == nil {
+		t.Fatal("expected issuer-mismatch rejection")
+	}
+	// A matching issuer but a token endpoint on a foreign origin (which would
+	// exfiltrate the code_verifier / refresh token) must be rejected.
+	foreignToken := *good
+	foreignToken.TokenEndpoint = "http://evil.test/oauth/token"
+	if err := foreignToken.Validate("http://localhost:4000"); err == nil {
+		t.Fatal("expected cross-origin token_endpoint rejection")
+	}
+}
+
+func TestForceRefreshRotatesValidToken(t *testing.T) {
+	useMockKeyring(t)
+	as := newFakeAS(t)
+	store := NewStore(as.origin())
+	orig := loopbackPorts
+	loopbackPorts = []int{0}
+	defer func() { loopbackPorts = orig }()
+
+	ctx := context.Background()
+	if _, err := Login(ctx, as.origin(), store, LoginOptions{Open: browserOpener(t), Out: io.Discard}); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	azr := Resolve(Credentials{}, store)
+
+	// The freshly-minted token is still valid; ForceRefresh must rotate it
+	// anyway (this is what breaks the WS token_expired clock-skew loop).
+	tok1, err := azr.BearerToken(ctx)
+	if err != nil || tok1 != "access-1" {
+		t.Fatalf("BearerToken before = %q, %v", tok1, err)
+	}
+	if err := azr.ForceRefresh(ctx); err != nil {
+		t.Fatalf("ForceRefresh: %v", err)
+	}
+	tok2, err := azr.BearerToken(ctx)
+	if err != nil || tok2 != "access-2" {
+		t.Fatalf("BearerToken after ForceRefresh = %q, %v (want access-2)", tok2, err)
+	}
+	reloaded, err := store.Load()
+	if err != nil || reloaded.RefreshToken != "refresh-2" {
+		t.Fatalf("rotated refresh token not persisted: %+v (%v)", reloaded, err)
+	}
+}
+
+func TestRetryTransportRefreshesOn401(t *testing.T) {
+	useMockKeyring(t)
+	as := newFakeAS(t)
+	store := NewStore(as.origin())
+	orig := loopbackPorts
+	loopbackPorts = []int{0}
+	defer func() { loopbackPorts = orig }()
+
+	ctx := context.Background()
+	if _, err := Login(ctx, as.origin(), store, LoginOptions{Open: browserOpener(t), Out: io.Discard}); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	SetDefault(Resolve(Credentials{}, store))
+	t.Cleanup(func() { SetDefault(nil) })
+
+	var mu sync.Mutex
+	var seen []string
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seen = append(seen, r.Header.Get("Authorization"))
+		mu.Unlock()
+		// The first (stale) token is rejected; the refreshed one is accepted.
+		if r.Header.Get("Authorization") == "Bearer access-1" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(api.Close)
+
+	client := &http.Client{Transport: NewRetryTransport(nil)}
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, api.URL, nil)
+	if err := Default().Authorize(ctx, req); err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 after refresh-and-retry, got %d", resp.StatusCode)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(seen) != 2 || seen[0] != "Bearer access-1" || seen[1] != "Bearer access-2" {
+		t.Fatalf("expected one 401 with access-1 then a retry with access-2, got %v", seen)
+	}
+}

--- a/internal/auth/discovery.go
+++ b/internal/auth/discovery.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2019-2026 Truestamp, Inc.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/truestamp/truestamp-cli/internal/httpclient"
+)
+
+// discoveryPath is the RFC 8414 authorization-server metadata path.
+const discoveryPath = "/.well-known/oauth-authorization-server"
+
+// Discovery is the subset of RFC 8414 authorization-server metadata the
+// CLI consumes. Endpoints are read from here (never hardcoded) so the
+// same binary works against dev/staging/prod, which differ only by origin.
+type Discovery struct {
+	Issuer                            string   `json:"issuer"`
+	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
+	TokenEndpoint                     string   `json:"token_endpoint"`
+	RevocationEndpoint                string   `json:"revocation_endpoint"`
+	RegistrationEndpoint              string   `json:"registration_endpoint"`
+	GrantTypesSupported               []string `json:"grant_types_supported"`
+	ResponseTypesSupported            []string `json:"response_types_supported"`
+	CodeChallengeMethodsSupported     []string `json:"code_challenge_methods_supported"`
+	ScopesSupported                   []string `json:"scopes_supported"`
+	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported"`
+}
+
+// Fetch retrieves and parses the authorization-server metadata for the
+// given base origin (scheme + host, e.g. "http://localhost:4000"). It
+// reuses the shared HTTP client (timeout, User-Agent, response-size cap).
+func Fetch(ctx context.Context, baseOrigin string) (*Discovery, error) {
+	origin := canonicalOrigin(baseOrigin)
+	if origin == "" {
+		return nil, fmt.Errorf("invalid base origin %q", baseOrigin)
+	}
+	body, err := httpclient.GetJSONCtx(ctx, origin+discoveryPath)
+	if err != nil {
+		return nil, fmt.Errorf("fetching %s: %w", discoveryPath, err)
+	}
+	var d Discovery
+	if err := json.Unmarshal(body, &d); err != nil {
+		return nil, fmt.Errorf("parsing authorization-server metadata: %w", err)
+	}
+	return &d, nil
+}
+
+// Validate checks that the discovery document is usable for the loopback
+// PKCE flow against the expected origin: it must carry the authorization
+// and token endpoints, advertise S256 PKCE, and its issuer must match the
+// configured origin (a guard against a misconfigured base_url silently
+// authenticating against the wrong server).
+func (d *Discovery) Validate(baseOrigin string) error {
+	if d.AuthorizationEndpoint == "" || d.TokenEndpoint == "" {
+		return fmt.Errorf("authorization server metadata is missing the authorization or token endpoint — OAuth may not be enabled on this server")
+	}
+	if !contains(d.CodeChallengeMethodsSupported, "S256") {
+		return fmt.Errorf("authorization server does not advertise S256 PKCE (got %v); refusing to fall back to a weaker method", d.CodeChallengeMethodsSupported)
+	}
+	origin := canonicalOrigin(baseOrigin)
+	if d.Issuer != "" && canonicalOrigin(d.Issuer) != origin {
+		return fmt.Errorf("issuer %q does not match the configured base URL %q; check base_url", d.Issuer, baseOrigin)
+	}
+	// Pin every advertised endpoint to the configured origin. The token,
+	// authorize, and revocation endpoints carry the PKCE code_verifier and
+	// the rotating refresh token; a metadata document that scattered them
+	// to a foreign host (while keeping a matching issuer) would exfiltrate
+	// those secrets. RFC 8414 recommends this same-origin pinning.
+	for _, ep := range []struct{ name, raw string }{
+		{"authorization_endpoint", d.AuthorizationEndpoint},
+		{"token_endpoint", d.TokenEndpoint},
+		{"revocation_endpoint", d.RevocationEndpoint},
+	} {
+		if ep.raw == "" {
+			continue
+		}
+		if canonicalOrigin(ep.raw) != origin {
+			return fmt.Errorf("%s %q is not on the configured origin %q; refusing", ep.name, ep.raw, origin)
+		}
+	}
+	return nil
+}
+
+// canonicalOrigin parses a URL and returns just its scheme+host, lowercased
+// scheme, with no trailing slash. Returns "" if the input cannot be parsed
+// into a scheme+host. Used both to derive the discovery URL and to key the
+// per-environment token store.
+func canonicalOrigin(raw string) string {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return ""
+	}
+	return (&url.URL{Scheme: strings.ToLower(u.Scheme), Host: u.Host}).String()
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/auth/fuzz_test.go
+++ b/internal/auth/fuzz_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2019-2026 Truestamp, Inc.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// FuzzDiscoveryValidate hardens the OAuth authorization-server metadata
+// path. The discovery document is network input — fetched from the
+// configured base origin — so a malicious or MITM'd server could return
+// arbitrary JSON. Validate and canonicalOrigin do URL/string work over the
+// parsed issuer + endpoints; they must never panic, for any parsed contents
+// and against any origin the CLI may be configured with.
+//
+// Seeds anchor the production-shaped doc plus the deliberately-rejected
+// shapes (cross-origin endpoint, plain-only PKCE, non-URL issuer) so the
+// replay run keeps exercising the Validate branches.
+func FuzzDiscoveryValidate(f *testing.F) {
+	f.Add([]byte(`{"issuer":"http://localhost:4000","authorization_endpoint":"http://localhost:4000/oauth/authorize","token_endpoint":"http://localhost:4000/oauth/token","revocation_endpoint":"http://localhost:4000/oauth/revoke","code_challenge_methods_supported":["S256"]}`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`{"issuer":"http://localhost:4000","authorization_endpoint":"http://localhost:4000/a","token_endpoint":"http://evil.test/t","code_challenge_methods_supported":["S256"]}`))
+	f.Add([]byte(`{"issuer":"::not a url::","token_endpoint":"","code_challenge_methods_supported":["plain"]}`))
+	f.Add([]byte(`{"code_challenge_methods_supported":[""],"authorization_endpoint":"   ","token_endpoint":"\t"}`))
+
+	origins := []string{"http://localhost:4000", "https://www.truestamp.com", "", "not a url", "http://"}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var d Discovery
+		if json.Unmarshal(data, &d) != nil {
+			return // Fetch surfaces the parse error; there's nothing to validate
+		}
+		// Must never panic for any parsed metadata document, for any origin.
+		for _, origin := range origins {
+			_ = d.Validate(origin)
+		}
+		_ = canonicalOrigin(d.Issuer)
+		_ = canonicalOrigin(d.TokenEndpoint)
+		_ = canonicalOrigin(d.AuthorizationEndpoint)
+	})
+}
+
+// FuzzSessionDecode hardens the token store's decode path. The persisted
+// session — a keychain value or the 0600 fallback file — is read back with
+// encoding/json into both the per-origin map (the file store) and a bare
+// Session. Garbage or a tampered file must yield a clean error, never a
+// panic.
+func FuzzSessionDecode(f *testing.F) {
+	f.Add([]byte(`{"http://localhost:4000":{"access_token":"a","refresh_token":"r","token_type":"Bearer","expiry":"2026-01-01T00:00:00Z"}}`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`not json`))
+	f.Add([]byte(`{"x":{"expiry":"garbage"}}`))
+	f.Add([]byte(`[1,2,3]`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var m map[string]Session
+		_ = json.Unmarshal(data, &m)
+		var s Session
+		_ = json.Unmarshal(data, &s)
+	})
+}

--- a/internal/auth/login.go
+++ b/internal/auth/login.go
@@ -1,0 +1,258 @@
+// Copyright (c) 2019-2026 Truestamp, Inc.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cli/browser"
+	"golang.org/x/oauth2"
+)
+
+// LoginOptions tunes the interactive login flow. The zero value is valid:
+// it opens the system browser and writes prompts to os.Stderr-equivalent
+// nil (suppressed). cmd populates Out and may override Open for tests.
+type LoginOptions struct {
+	// Open opens a URL in the user's browser. Defaults to browser.OpenURL.
+	Open func(string) error
+	// Out receives the human-facing "open this URL" guidance. Defaults to
+	// io.Discard.
+	Out io.Writer
+}
+
+// callbackResult carries the loopback handler's outcome to Login.
+type callbackResult struct {
+	code string
+	err  error
+}
+
+// Login runs the browser-based loopback Authorization Code + PKCE flow
+// against baseOrigin, persists the resulting session via store, and returns
+// it. ctx bounds the whole flow (caller should pass a generous deadline —
+// the user has to sign in and consent in a browser).
+func Login(ctx context.Context, baseOrigin string, store Store, opts LoginOptions) (*Session, error) {
+	if opts.Open == nil {
+		opts.Open = browser.OpenURL
+	}
+	if opts.Out == nil {
+		opts.Out = io.Discard
+	}
+
+	disc, err := Fetch(ctx, baseOrigin)
+	if err != nil {
+		return nil, err
+	}
+	if err := disc.Validate(baseOrigin); err != nil {
+		return nil, err
+	}
+
+	ln, redirectURI, err := listenLoopback()
+	if err != nil {
+		return nil, err
+	}
+	defer ln.Close()
+
+	verifier := oauth2.GenerateVerifier()
+	state, err := randString(32)
+	if err != nil {
+		return nil, fmt.Errorf("generating state: %w", err)
+	}
+
+	conf := &oauth2.Config{
+		ClientID:    ClientID,
+		RedirectURL: redirectURI,
+		Scopes:      Scopes,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   disc.AuthorizationEndpoint,
+			TokenURL:  disc.TokenEndpoint,
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+	}
+	authURL := conf.AuthCodeURL(state, oauth2.S256ChallengeOption(verifier))
+
+	resCh := make(chan callbackResult, 1)
+	srv := &http.Server{
+		Handler:           callbackHandler(state, resCh),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() { _ = srv.Serve(ln) }()
+	defer func() {
+		shutCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutCtx)
+	}()
+
+	fmt.Fprintln(opts.Out, "Opening your browser to sign in:")
+	fmt.Fprintln(opts.Out, "  "+authURL)
+	if err := opts.Open(authURL); err != nil {
+		fmt.Fprintln(opts.Out, "Could not open a browser automatically — visit the URL above to continue.")
+	}
+
+	var code string
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("login timed out or was cancelled: %w", ctx.Err())
+	case r := <-resCh:
+		if r.err != nil {
+			return nil, r.err
+		}
+		code = r.code
+	}
+
+	tok, err := conf.Exchange(tokenContext(ctx), code, oauth2.VerifierOption(verifier))
+	if err != nil {
+		return nil, fmt.Errorf("exchanging authorization code: %w", err)
+	}
+
+	sess := sessionFromToken(disc, tok)
+	if err := store.Save(sess); err != nil {
+		return nil, fmt.Errorf("saving session: %w", err)
+	}
+	return &sess, nil
+}
+
+// Logout best-effort revokes the stored refresh token (RFC 7009) and clears
+// the local session. Revocation failures are non-fatal — the local session
+// is cleared regardless, and access tokens are short-lived stateless JWTs.
+func Logout(ctx context.Context, store Store) (revoked bool, err error) {
+	sess, loadErr := store.Load()
+	if loadErr == nil && sess.RevocationURL != "" && sess.RefreshToken != "" {
+		if rerr := revokeToken(ctx, sess.RevocationURL, sess.RefreshToken); rerr == nil {
+			revoked = true
+		}
+	}
+	return revoked, store.Clear()
+}
+
+// revokeToken posts an RFC 7009 revocation for a refresh token.
+func revokeToken(ctx context.Context, revocationURL, refreshToken string) error {
+	form := url.Values{
+		"token":           {refreshToken},
+		"token_type_hint": {"refresh_token"},
+		"client_id":       {ClientID},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, revocationURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := (&http.Client{Timeout: 15 * time.Second}).Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("revocation returned HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// listenLoopback binds the first available fixed loopback port and returns
+// the listener plus the exact redirect_uri to advertise (which must match a
+// server-registered redirect_uri byte-for-byte).
+func listenLoopback() (net.Listener, string, error) {
+	var lastErr error
+	for _, port := range loopbackPorts {
+		ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+		if err == nil {
+			// Derive the redirect_uri from the actually-bound port. For the
+			// fixed ports this equals the configured port; tests inject port
+			// 0 and get the real ephemeral port here.
+			actual := ln.Addr().(*net.TCPAddr).Port
+			return ln, fmt.Sprintf("http://127.0.0.1:%d%s", actual, callbackPath), nil
+		}
+		lastErr = err
+	}
+	return nil, "", fmt.Errorf("could not bind a loopback callback port (tried %v): %w — close whatever is using them and retry", loopbackPorts, lastErr)
+}
+
+// callbackHandler serves the single OAuth redirect, validates state, and
+// reports the code (or error) exactly once.
+func callbackHandler(state string, resCh chan<- callbackResult) http.Handler {
+	var once sync.Once
+	send := func(r callbackResult) { once.Do(func() { resCh <- r }) }
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != callbackPath {
+			http.NotFound(w, r)
+			return
+		}
+		q := r.URL.Query()
+		// A request that doesn't carry THIS flow's crypto-random state is
+		// not our redirect — it's a stray probe (a co-resident process, a
+		// browser prefetch) hitting the fixed loopback port. Reject it with
+		// a 400 but DO NOT resolve the flow, so it can't abort a legitimate
+		// login. Only a matching-state request (success or an explicit
+		// user denial) is terminal; the ctx deadline bounds the wait.
+		if q.Get("state") != state {
+			http.Error(w, "unrecognized or missing state parameter", http.StatusBadRequest)
+			return
+		}
+		if e := q.Get("error"); e != "" {
+			desc := q.Get("error_description")
+			writeResultPage(w, false, "Authorization was denied.")
+			send(callbackResult{err: fmt.Errorf("authorization denied: %s %s", e, desc)})
+			return
+		}
+		code := q.Get("code")
+		if code == "" {
+			writeResultPage(w, false, "No authorization code was returned.")
+			send(callbackResult{err: errors.New("no authorization code in callback")})
+			return
+		}
+		writeResultPage(w, true, "You're signed in to the Truestamp CLI. You can close this tab and return to your terminal.")
+		send(callbackResult{code: code})
+	})
+}
+
+// writeResultPage renders a minimal browser landing page.
+func writeResultPage(w http.ResponseWriter, ok bool, msg string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	status := "Success"
+	color := "#16a34a"
+	if !ok {
+		status = "Login failed"
+		color = "#dc2626"
+	}
+	fmt.Fprintf(w, `<!doctype html><html><head><meta charset="utf-8"><title>Truestamp CLI</title>
+<style>body{font-family:system-ui,sans-serif;background:#0b0b0c;color:#e5e5e5;display:flex;min-height:100vh;align-items:center;justify-content:center;margin:0}
+.card{max-width:30rem;padding:2rem;text-align:center}h1{color:%s;margin:0 0 .5rem}p{color:#a3a3a3;line-height:1.5}</style></head>
+<body><div class="card"><h1>%s</h1><p>%s</p></div></body></html>`, color, status, msg)
+}
+
+// sessionFromToken assembles a Session from discovery + an exchanged token.
+func sessionFromToken(disc *Discovery, tok *oauth2.Token) Session {
+	scope, _ := tok.Extra("scope").(string)
+	return Session{
+		Issuer:        disc.Issuer,
+		AuthURL:       disc.AuthorizationEndpoint,
+		TokenURL:      disc.TokenEndpoint,
+		RevocationURL: disc.RevocationEndpoint,
+		AccessToken:   tok.AccessToken,
+		RefreshToken:  tok.RefreshToken,
+		TokenType:     tok.TokenType,
+		Scope:         scope,
+		Expiry:        tok.Expiry,
+	}
+}
+
+// randString returns n cryptographically-random bytes, base64url-encoded.
+func randString(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}

--- a/internal/auth/resolve.go
+++ b/internal/auth/resolve.go
@@ -1,0 +1,286 @@
+// Copyright (c) 2019-2026 Truestamp, Inc.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// Credentials carries the resolved API-key state used by [Resolve].
+type Credentials struct {
+	// APIKey is the merged api_key value (config file, env, or flag).
+	APIKey string
+	// APIKeyExplicit is true when the key came from an intentional
+	// override — the --api-key flag or TRUESTAMP_API_KEY env — as opposed
+	// to the config file. An explicit key wins over an OAuth session so
+	// CI/headless behavior is deterministic.
+	APIKeyExplicit bool
+}
+
+// Resolve selects the active credential per the documented precedence:
+// explicit API key → OAuth session → config-file API key → none.
+func Resolve(creds Credentials, store Store) Authorizer {
+	if creds.APIKeyExplicit && creds.APIKey != "" {
+		return apiKeyAuthorizer{key: creds.APIKey}
+	}
+	if sess, err := store.Load(); err == nil && sess.RefreshToken != "" {
+		return newOAuthAuthorizer(sess, store)
+	}
+	if creds.APIKey != "" {
+		return apiKeyAuthorizer{key: creds.APIKey}
+	}
+	return noneAuthorizer{}
+}
+
+// APIKeyAuthorizer returns an Authorizer that presents key as a Bearer
+// token. Exported for cmd wiring and for tests that exercise the API-key
+// path directly.
+func APIKeyAuthorizer(key string) Authorizer { return apiKeyAuthorizer{key: key} }
+
+// --- API-key authorizer -----------------------------------------------------
+
+type apiKeyAuthorizer struct{ key string }
+
+func (a apiKeyAuthorizer) Mode() Mode { return ModeAPIKey }
+
+func (a apiKeyAuthorizer) Authorize(_ context.Context, req *http.Request) error {
+	req.Header.Set("Authorization", "Bearer "+a.key)
+	return nil
+}
+
+func (a apiKeyAuthorizer) BearerToken(context.Context) (string, error) {
+	return a.key, nil
+}
+
+// ForceRefresh is a no-op: an API key is long-lived and not refreshable.
+func (a apiKeyAuthorizer) ForceRefresh(context.Context) error { return nil }
+
+// AccessTokenExpiry is the zero time: an API key has no expiry.
+func (a apiKeyAuthorizer) AccessTokenExpiry() time.Time { return time.Time{} }
+
+// --- no-credentials authorizer ----------------------------------------------
+
+type noneAuthorizer struct{}
+
+func (noneAuthorizer) Mode() Mode { return ModeNone }
+
+// Authorize is a no-op: a genuinely public request still goes out, and the
+// server returns 401 if the resource needs auth.
+func (noneAuthorizer) Authorize(context.Context, *http.Request) error { return nil }
+
+func (noneAuthorizer) BearerToken(context.Context) (string, error) {
+	return "", ErrNoCredentials
+}
+
+// ForceRefresh is a no-op: there is no credential to refresh.
+func (noneAuthorizer) ForceRefresh(context.Context) error { return nil }
+
+// AccessTokenExpiry is the zero time: there is no credential.
+func (noneAuthorizer) AccessTokenExpiry() time.Time { return time.Time{} }
+
+// --- OAuth authorizer -------------------------------------------------------
+
+// oauthAuthorizer holds a self-managed access/refresh token pair. It caches
+// a valid access token and runs the refresh grant when the token is expired
+// (or when ForceRefresh is called), persisting the rotated refresh token on
+// every refresh. A mutex serializes refreshes so concurrent HTTP commands
+// and the console WebSocket never trigger a refresh storm.
+type oauthAuthorizer struct {
+	conf  *oauth2.Config
+	store Store
+
+	mu   sync.Mutex
+	tok  *oauth2.Token
+	sess Session
+}
+
+func newOAuthAuthorizer(sess Session, store Store) Authorizer {
+	return &oauthAuthorizer{
+		conf:  refreshConfig(sess),
+		store: store,
+		tok: &oauth2.Token{
+			AccessToken:  sess.AccessToken,
+			RefreshToken: sess.RefreshToken,
+			TokenType:    sess.TokenType,
+			Expiry:       sess.Expiry,
+		},
+		sess: sess,
+	}
+}
+
+func (a *oauthAuthorizer) Mode() Mode { return ModeOAuth }
+
+func (a *oauthAuthorizer) Authorize(ctx context.Context, req *http.Request) error {
+	tok, err := a.token(ctx, false)
+	if err != nil {
+		return err
+	}
+	tok.SetAuthHeader(req)
+	return nil
+}
+
+func (a *oauthAuthorizer) BearerToken(ctx context.Context) (string, error) {
+	tok, err := a.token(ctx, false)
+	if err != nil {
+		return "", err
+	}
+	return tok.AccessToken, nil
+}
+
+// ForceRefresh runs the refresh grant unconditionally (skipping the cached
+// access token's validity check) so the next request carries a brand-new
+// token even when the local copy still looks valid but the server rejected
+// it (clock skew, server-side expiry/revocation).
+func (a *oauthAuthorizer) ForceRefresh(ctx context.Context) error {
+	_, err := a.token(ctx, true)
+	return err
+}
+
+// AccessTokenExpiry returns the cached access token's expiry so the console
+// WebSocket can schedule a proactive in-band refresh before the server
+// force-disconnects.
+func (a *oauthAuthorizer) AccessTokenExpiry() time.Time {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.tok == nil {
+		return time.Time{}
+	}
+	return a.tok.Expiry
+}
+
+// token returns a valid access token. It refreshes (and persists the
+// rotated refresh token) when the cached token is expired or force is set,
+// translating a dead-session refresh failure into [ErrSessionExpired].
+func (a *oauthAuthorizer) token(ctx context.Context, force bool) (*oauth2.Token, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if !force && a.tok.Valid() {
+		return a.tok, nil
+	}
+	// A source seeded with only the refresh token (no access token, zero
+	// expiry) treats itself as expired, so the first Token() call runs the
+	// refresh grant. The 30s-bounded token client honors the caller's ctx
+	// for cancellation.
+	src := a.conf.TokenSource(tokenContext(ctx), &oauth2.Token{RefreshToken: a.tok.RefreshToken})
+	nt, err := src.Token()
+	if err != nil {
+		if IsInvalidGrant(err) {
+			return nil, ErrSessionExpired
+		}
+		return nil, err
+	}
+	a.tok = nt
+	a.sess.AccessToken = nt.AccessToken
+	a.sess.RefreshToken = nt.RefreshToken
+	a.sess.TokenType = nt.TokenType
+	a.sess.Expiry = nt.Expiry
+	if scope, ok := nt.Extra("scope").(string); ok && scope != "" {
+		a.sess.Scope = scope
+	}
+	// Best-effort persist: a failed write must not break the request — the
+	// in-memory token is still valid for this process.
+	_ = a.store.Save(a.sess)
+	return a.tok, nil
+}
+
+// refreshConfig builds the oauth2.Config used for refresh (and revoke).
+// AuthStyleInParams is set because the CLI is a public client
+// (token_endpoint_auth_method=none): client_id goes in the form body, not
+// HTTP Basic — and we skip oauth2's auth-style autodetect probe.
+func refreshConfig(sess Session) *oauth2.Config {
+	return &oauth2.Config{
+		ClientID: ClientID,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   sess.AuthURL,
+			TokenURL:  sess.TokenURL,
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+	}
+}
+
+// --- reactive 401 retry transport -------------------------------------------
+
+// retryTransport retries an OAuth-authenticated request once after forcing a
+// token refresh when the server returns 401. The server's OAuth→API-key
+// fallback means an expired OAuth token can surface as a bare 401 without a
+// `WWW-Authenticate` challenge, so the contract is "treat any 401 in OAuth
+// mode as refresh-and-retry-once" — implemented here, centrally, for every
+// HTTP call site.
+type retryTransport struct{ base http.RoundTripper }
+
+// NewRetryTransport wraps base (or http.DefaultTransport) with the reactive
+// 401 → refresh → retry-once behavior. Install it on the shared HTTP client.
+func NewRetryTransport(base http.RoundTripper) http.RoundTripper {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return retryTransport{base: base}
+}
+
+func (t retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err != nil || resp.StatusCode != http.StatusUnauthorized {
+		return resp, err
+	}
+	// Only retry requests WE authenticated (they carry a Bearer header) in
+	// OAuth mode — never an unrelated 401 from an external API or an
+	// API-key request (which can't be refreshed).
+	azr := Default()
+	if azr.Mode() != ModeOAuth || req.Header.Get("Authorization") == "" {
+		return resp, err
+	}
+	// Force a refresh; if the session is dead (or the body can't be
+	// rewound), surface the original 401.
+	if rerr := azr.ForceRefresh(req.Context()); rerr != nil {
+		return resp, err
+	}
+	if req.Body != nil {
+		if req.GetBody == nil {
+			return resp, err
+		}
+		body, berr := req.GetBody()
+		if berr != nil {
+			return resp, err
+		}
+		req.Body = body
+	}
+	if aerr := azr.Authorize(req.Context(), req); aerr != nil {
+		return resp, err
+	}
+	drainAndClose(resp)
+	return t.base.RoundTrip(req)
+}
+
+func drainAndClose(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64<<10))
+	_ = resp.Body.Close()
+}
+
+// IsInvalidGrant reports whether err is an OAuth `invalid_grant` token
+// error — the signal that a refresh token is expired, reused, or revoked
+// and the session is permanently dead (the caller should stop retrying and
+// prompt re-login).
+func IsInvalidGrant(err error) bool {
+	var re *oauth2.RetrieveError
+	if errors.As(err, &re) {
+		return re.ErrorCode == "invalid_grant"
+	}
+	return false
+}
+
+// tokenContext returns ctx carrying a dedicated HTTP client for OAuth token
+// endpoint calls (a bounded timeout, independent of the per-command client).
+func tokenContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Timeout: 30 * time.Second})
+}

--- a/internal/auth/store.go
+++ b/internal/auth/store.go
@@ -1,0 +1,192 @@
+// Copyright (c) 2019-2026 Truestamp, Inc.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/zalando/go-keyring"
+)
+
+// keyringService is the OS-keychain service name under which sessions are
+// stored. The account/key within the service is the base origin, so dev
+// (localhost) and prod sessions never collide.
+const keyringService = "truestamp-cli"
+
+// ErrNoSession means no OAuth session is stored for the origin.
+var ErrNoSession = errors.New("no oauth session stored")
+
+// Session is the persisted OAuth state for one server origin. The endpoint
+// URLs are captured at login so token refresh and revocation never need a
+// fresh discovery round-trip during normal operation.
+type Session struct {
+	Issuer        string    `json:"issuer"`
+	AuthURL       string    `json:"auth_url"`
+	TokenURL      string    `json:"token_url"`
+	RevocationURL string    `json:"revocation_url,omitempty"`
+	AccessToken   string    `json:"access_token"`
+	RefreshToken  string    `json:"refresh_token"`
+	TokenType     string    `json:"token_type"`
+	Scope         string    `json:"scope,omitempty"`
+	Expiry        time.Time `json:"expiry"`
+}
+
+// Store persists [Session]s for a single server origin. It prefers the OS
+// keychain (macOS Keychain, libsecret/SecretService, Windows credential
+// manager) and transparently falls back to a 0600 JSON file under the
+// user cache dir when no keychain is available (e.g. headless Linux).
+// Reads consult both backends so a session written under one is still
+// found if availability changes between runs.
+type Store struct {
+	origin string
+}
+
+// NewStore returns a Store keyed by the canonical origin of baseURL.
+func NewStore(baseURL string) Store {
+	return Store{origin: canonicalOrigin(baseURL)}
+}
+
+// Load returns the stored session for the origin, or [ErrNoSession].
+func (s Store) Load() (Session, error) {
+	if v, err := keyring.Get(keyringService, s.origin); err == nil {
+		var sess Session
+		if json.Unmarshal([]byte(v), &sess) == nil && sess.RefreshToken != "" {
+			return sess, nil
+		}
+	}
+	return s.fileLoad()
+}
+
+// Save persists the session, preferring the keychain and falling back to
+// the 0600 file when the keychain write fails (unsupported/unavailable).
+func (s Store) Save(sess Session) error {
+	b, err := json.Marshal(sess) //#nosec G117 -- deliberate: serializing the OAuth session for the OS keychain / 0600-file token store is the store's purpose, not a leak
+	if err != nil {
+		return err
+	}
+	if err := keyring.Set(keyringService, s.origin, string(b)); err == nil {
+		// Keychain is the single source of truth on success: drop any stale
+		// 0600-file copy for this origin so a later load can't return an
+		// out-of-date session from the fallback backend.
+		_ = s.fileClear()
+		return nil
+	}
+	return s.fileSave(sess)
+}
+
+// Clear removes the session from both backends. Missing entries are not an
+// error (logout is idempotent).
+func (s Store) Clear() error {
+	_ = keyring.Delete(keyringService, s.origin)
+	return s.fileClear()
+}
+
+// fileStorePath is the fallback file location.
+func (s Store) fileStorePath() (string, error) {
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "truestamp", "oauth.json"), nil
+}
+
+func (s Store) fileLoad() (Session, error) {
+	p, err := s.fileStorePath()
+	if err != nil {
+		return Session{}, ErrNoSession
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return Session{}, ErrNoSession
+	}
+	var m map[string]Session
+	if json.Unmarshal(b, &m) != nil {
+		return Session{}, ErrNoSession
+	}
+	sess, ok := m[s.origin]
+	if !ok || sess.RefreshToken == "" {
+		return Session{}, ErrNoSession
+	}
+	return sess, nil
+}
+
+func (s Store) fileSave(sess Session) error {
+	p, err := s.fileStorePath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0700); err != nil {
+		return err
+	}
+	m := map[string]Session{}
+	if b, err := os.ReadFile(p); err == nil {
+		_ = json.Unmarshal(b, &m)
+	}
+	m[s.origin] = sess
+	return writeFile0600(p, m)
+}
+
+func (s Store) fileClear() error {
+	p, err := s.fileStorePath()
+	if err != nil {
+		return nil
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return nil
+	}
+	m := map[string]Session{}
+	if json.Unmarshal(b, &m) != nil {
+		return nil
+	}
+	if _, ok := m[s.origin]; !ok {
+		return nil
+	}
+	delete(m, s.origin)
+	if len(m) == 0 {
+		return os.Remove(p)
+	}
+	return writeFile0600(p, m)
+}
+
+// writeFile0600 atomically writes m as indented JSON with 0600 perms.
+func writeFile0600(path string, m map[string]Session) error {
+	b, err := json.MarshalIndent(m, "", "  ") //#nosec G117 -- deliberate: this is the 0600-file token store; the file is created mode 0600 and the bytes are the session we intend to persist
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0600); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmp, 0600); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		// Don't leave a 0600 temp file containing live tokens behind.
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// Location reports where a session for this origin is persisted, for
+// display after login. It probes the keychain first, then the file
+// fallback, so the message reflects the backend actually used.
+func (s Store) Location() string {
+	if _, err := keyring.Get(keyringService, s.origin); err == nil {
+		return "OS keychain"
+	}
+	if p, err := s.fileStorePath(); err == nil {
+		if _, ferr := os.Stat(p); ferr == nil {
+			return p + " (0600 — no OS keychain available)"
+		}
+	}
+	return "OS keychain (0600 file fallback)"
+}

--- a/internal/beacons/client.go
+++ b/internal/beacons/client.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 
 	"github.com/gofrs/uuid/v5"
+	"github.com/truestamp/truestamp-cli/internal/auth"
 	"github.com/truestamp/truestamp-cli/internal/httpclient"
 )
 
@@ -65,10 +66,11 @@ func (e *APIError) Error() string {
 func (e *APIError) Unwrap() error { return e.sentinel }
 
 // Config carries the subset of runtime configuration needed for a request.
-// Kept small to avoid importing the top-level config package.
+// Kept small to avoid importing the top-level config package. The
+// credential is supplied out-of-band by the process-wide [auth.Authorizer]
+// (set in cmd/root); only the tenant scoping lives here.
 type Config struct {
 	APIURL string // e.g. https://www.truestamp.com/api/json
-	APIKey string // Bearer token (never logged)
 	Team   string // optional tenant id
 }
 
@@ -123,15 +125,17 @@ func ByHash(ctx context.Context, cfg Config, hash string) (*Beacon, error) {
 // doGet issues an authenticated GET and returns the response body on 2xx.
 // On non-2xx returns an *APIError wrapping one of the class sentinels.
 func doGet(ctx context.Context, cfg Config, path string) ([]byte, error) {
-	if cfg.APIKey == "" {
-		return nil, &APIError{Status: 401, Detail: "API key not set", sentinel: ErrUnauthorized}
+	if auth.Default().Mode() == auth.ModeNone {
+		return nil, &APIError{Status: 401, Detail: "not authenticated", sentinel: ErrUnauthorized}
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.APIURL+path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Accept", "application/vnd.api+json")
-	req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
+	if err := auth.AuthorizeRequest(ctx, req); err != nil {
+		return nil, &APIError{Status: 401, Detail: err.Error(), sentinel: ErrUnauthorized}
+	}
 	if cfg.Team != "" {
 		req.Header.Set("tenant", cfg.Team)
 	}

--- a/internal/beacons/client_test.go
+++ b/internal/beacons/client_test.go
@@ -8,9 +8,23 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/truestamp/truestamp-cli/internal/auth"
 )
+
+// TestMain installs an api-key Authorizer for the whole package so the
+// beacons client authorizes outbound requests (it 401s when
+// auth.Default().Mode() == auth.ModeNone). The key matches the
+// "Bearer test-key" header these tests assert.
+func TestMain(m *testing.M) {
+	auth.SetDefault(auth.APIKeyAuthorizer("test-key"))
+	code := m.Run()
+	auth.SetDefault(nil)
+	os.Exit(code)
+}
 
 const (
 	validID    = "019db702-b08c-73dc-a7cd-2c5e011f1dad"
@@ -24,7 +38,7 @@ const (
 func newServer(t *testing.T, fn http.HandlerFunc) (Config, func()) {
 	t.Helper()
 	srv := httptest.NewServer(fn)
-	return Config{APIURL: srv.URL, APIKey: "test-key"}, srv.Close
+	return Config{APIURL: srv.URL}, srv.Close
 }
 
 func TestLatest_Bare(t *testing.T) {
@@ -229,6 +243,12 @@ func TestError_5xx(t *testing.T) {
 }
 
 func TestError_MissingAPIKey(t *testing.T) {
+	// With no Authorizer (ModeNone), the client must short-circuit with
+	// ErrUnauthorized before touching the network. Restore the
+	// package-wide api-key authorizer afterward.
+	auth.SetDefault(nil)
+	t.Cleanup(func() { auth.SetDefault(auth.APIKeyAuthorizer("test-key")) })
+
 	_, err := Latest(context.Background(), Config{APIURL: "http://unused"})
 	if !errors.Is(err, ErrUnauthorized) {
 		t.Fatalf("expected ErrUnauthorized, got %v", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,7 +49,14 @@ type Config struct {
 	WebSocketURL string `koanf:"-"`
 	HealthURL    string `koanf:"-"`
 
-	APIKey      string `koanf:"api_key"`
+	APIKey string `koanf:"api_key"`
+	// APIKeyExplicit is true when api_key came from an intentional
+	// override — the --api-key flag or the TRUESTAMP_API_KEY env var —
+	// rather than the config file. An explicit key wins over a stored
+	// OAuth session so CI/headless behavior stays deterministic. Computed
+	// during Load; not user-settable.
+	APIKeyExplicit bool `koanf:"-"`
+
 	Team        string `koanf:"team"`
 	HTTPTimeout string `koanf:"http_timeout"`
 	// CosignPath pins the cosign binary used during `truestamp upgrade`.
@@ -237,6 +244,12 @@ func Load(configPath string, flags *pflag.FlagSet) (*Config, error) {
 	if err := k.Unmarshal("", &cfg); err != nil {
 		return nil, fmt.Errorf("unmarshaling config: %w", err)
 	}
+
+	// Record whether the API key was supplied explicitly (env or flag) so
+	// the auth resolver can let an explicit key override a stored OAuth
+	// session. A key sitting in the config file is not "explicit".
+	cfg.APIKeyExplicit = os.Getenv("TRUESTAMP_API_KEY") != "" ||
+		(flags != nil && flags.Lookup("api-key") != nil && flags.Changed("api-key"))
 
 	// Compose the canonical Truestamp service URLs from BaseURL. The path
 	// layout is fixed by the server (lib/truestamp_web/router.ex) so we

--- a/internal/console/app.go
+++ b/internal/console/app.go
@@ -6,6 +6,7 @@ package console
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	lipgloss "charm.land/lipgloss/v2"
+	"github.com/truestamp/truestamp-cli/internal/auth"
 	"github.com/truestamp/truestamp-cli/internal/console/chrome"
 	"github.com/truestamp/truestamp-cli/internal/console/keys"
 	"github.com/truestamp/truestamp-cli/internal/logging"
@@ -27,11 +29,25 @@ func Run(ctx context.Context, opts Options) error {
 		logger = logging.Discard()
 	}
 
-	client, err := wschannel.New(wschannel.Options{
-		URL:    opts.WSURL,
-		APIKey: opts.APIKey,
-		Logger: logger,
-	})
+	wsOpts := wschannel.Options{URL: opts.WSURL, Logger: logger}
+	switch {
+	case opts.Authorizer != nil && opts.Authorizer.Mode() == auth.ModeOAuth:
+		// OAuth: header auth with a per-dial fresh token, and a dead
+		// session is fatal (stop retrying → prompt re-login).
+		wsOpts.BearerToken = opts.Authorizer.BearerToken
+		wsOpts.ForceRefresh = opts.Authorizer.ForceRefresh
+		wsOpts.AccessTokenExpiry = opts.Authorizer.AccessTokenExpiry
+		wsOpts.FatalDialErr = func(err error) bool { return errors.Is(err, auth.ErrSessionExpired) }
+	case opts.Authorizer != nil:
+		// API-key mode: resolve the key once for query-param auth.
+		key, kerr := opts.Authorizer.BearerToken(ctx)
+		if kerr != nil {
+			return fmt.Errorf("resolving credential: %w", kerr)
+		}
+		wsOpts.APIKey = key
+	}
+
+	client, err := wschannel.New(wsOpts)
 	if err != nil {
 		return fmt.Errorf("wschannel.New: %w", err)
 	}
@@ -54,6 +70,7 @@ func Run(ctx context.Context, opts Options) error {
 		defer cancel()
 		raw, err := client.Connect(connectCtx)
 		if err != nil {
+			logger.Warn("console connect failed", "err", err.Error())
 			p.Send(connectFailedMsg{Err: err})
 			return
 		}
@@ -62,6 +79,7 @@ func Run(ctx context.Context, opts Options) error {
 			p.Send(connectFailedMsg{Err: fmt.Errorf("decode welcome: %w", jerr)})
 			return
 		}
+		logger.Info("console connected", "ws_url", opts.WSURL)
 		// Join the auxiliary clock topic on the same socket. Any
 		// failure here is non-fatal: the lobby still works without the
 		// header clock; log it and move on.
@@ -78,8 +96,12 @@ func Run(ctx context.Context, opts Options) error {
 
 // Options carries the runtime configuration into the TUI.
 type Options struct {
-	WSURL  string
-	APIKey string
+	WSURL string
+
+	// Authorizer supplies the WebSocket credential: OAuth (Bearer header,
+	// auto-refreshed) or API key (query param). The Teams pane's HTTP
+	// calls use the process-wide auth.Default() independently.
+	Authorizer auth.Authorizer
 
 	// APIURL is the base JSON:API URL (e.g. https://www.truestamp.com/api/json).
 	// Threaded into the Teams pane so it can call ListMyMemberships /
@@ -243,7 +265,7 @@ func newModel(client *wschannel.Client, opts Options, log *slog.Logger) *model {
 	m.scope = activeScope{PreferredID: opts.ActiveTeamID}
 	m.monitor = newMonitorModel(client, log)
 	m.newItem = newNewItemModel(client)
-	m.team = newTeamModel(opts.APIURL, opts.APIKey, &m.scope, client)
+	m.team = newTeamModel(opts.APIURL, &m.scope, client)
 	m.connection = newConnectionModel(opts.LogFilePath, opts.ConfigFilePath, opts.HealthTargets, &m.scope)
 	return m
 }
@@ -454,6 +476,23 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.lastOutageMark = now
 		}
 		return m, reconnectTickCmd()
+
+	case tokenRefreshingMsg:
+		// The OAuth access token expired; the client is transparently
+		// re-dialling with a refreshed token. The reconnect events that
+		// follow drive the visible header status — just keep pumping.
+		m.log.Info("oauth access token expired; refreshing session in-band")
+		return m, waitForPush(m.client)
+
+	case authFailedMsg:
+		// The OAuth session is permanently dead; the client stopped
+		// reconnecting. Surface a clear re-login prompt on the
+		// Connection pane.
+		m.state = connFailed
+		m.connErr = fmt.Errorf("OAuth session expired — run `truestamp auth login`, then reopen the console")
+		m.connection.setConnError(m.connErr, m.opts.WSURL)
+		m.log.Warn("oauth session dead; reconnect stopped", "reason", msg.Reason)
+		return m, m.activatePane(paneConnection)
 
 	case pushMsg:
 		m.monitor.handlePush(msg)

--- a/internal/console/connection_test.go
+++ b/internal/console/connection_test.go
@@ -78,7 +78,7 @@ func TestRenderErrorSectionAuthFailure(t *testing.T) {
 	out := stripANSI(m.renderErrorSection(120))
 
 	wantParts := []string{
-		"The server rejected your API key.",
+		"The server rejected your credentials.",
 		"truestamp auth login",
 	}
 	for _, want := range wantParts {

--- a/internal/console/connerror.go
+++ b/internal/console/connerror.go
@@ -4,7 +4,10 @@
 package console
 
 import (
+	"errors"
 	"strings"
+
+	"github.com/truestamp/truestamp-cli/internal/auth"
 )
 
 // connErrorKind classifies common WebSocket connect-time failures so
@@ -37,6 +40,12 @@ const (
 func classifyConnError(err error) connErrorKind {
 	if err == nil {
 		return connErrorUnknown
+	}
+	// A dead or absent OAuth session is an auth failure, not a generic
+	// transport error — route it to the auth kind so the user is told to
+	// re-authenticate rather than to check their network.
+	if errors.Is(err, auth.ErrSessionExpired) || errors.Is(err, auth.ErrNoCredentials) {
+		return connErrorAuth
 	}
 	s := err.Error()
 
@@ -117,7 +126,7 @@ func (k connErrorKind) title() string {
 	case connErrorTLS:
 		return "TLS / certificate verification failed."
 	case connErrorAuth:
-		return "The server rejected your API key."
+		return "The server rejected your credentials."
 	case connErrorNotFound:
 		return "The server is reachable but does not expose a console endpoint at this URL."
 	case connErrorServerError:

--- a/internal/console/messages.go
+++ b/internal/console/messages.go
@@ -64,6 +64,18 @@ type reconnectingMsg struct {
 // passed since the last outage marker to inject a fresh one.
 type reconnectTickMsg struct{}
 
+// tokenRefreshingMsg fires when the server signalled OAuth access-token
+// expiry and the client is transparently re-dialling with a refreshed
+// token. Informational; the reconnect messages carry the visible status.
+type tokenRefreshingMsg struct{}
+
+// authFailedMsg fires when the OAuth session is permanently dead (refresh
+// token expired/revoked) and the client has stopped reconnecting. The user
+// must re-authenticate.
+type authFailedMsg struct {
+	Reason string
+}
+
 // welcomeMsg is dispatched after a successful Connect — it carries the
 // initial welcome envelope from the server (scope summary, stream catalog,
 // server build info).
@@ -234,6 +246,18 @@ func waitForPush(client *wschannel.Client) tea.Cmd {
 				at, _ := time.Parse(time.RFC3339Nano, s.NextAttemptAt)
 				return reconnectingMsg{Attempt: s.Attempt, NextAttemptAt: at}
 			}
+		}
+
+		// OAuth token lifecycle events from the transport.
+		if p.Event == wschannel.TokenRefreshEvent {
+			return tokenRefreshingMsg{}
+		}
+		if p.Event == wschannel.AuthFailedEvent {
+			var s struct {
+				Reason string `json:"reason"`
+			}
+			_ = json.Unmarshal(p.Payload, &s)
+			return authFailedMsg{Reason: s.Reason}
 		}
 
 		return pushMsg{Topic: p.Topic, Event: p.Event, Payload: p.Payload}

--- a/internal/console/team.go
+++ b/internal/console/team.go
@@ -64,7 +64,6 @@ type teamSwitcher interface {
 //     console catches up to where they left off.
 type teamModel struct {
 	apiURL string
-	apiKey string
 	client teamSwitcher
 
 	// scope points at the root model's activeScope so the pane
@@ -86,10 +85,9 @@ type teamModel struct {
 	noticeError bool
 }
 
-func newTeamModel(apiURL, apiKey string, scope *activeScope, client teamSwitcher) *teamModel {
+func newTeamModel(apiURL string, scope *activeScope, client teamSwitcher) *teamModel {
 	return &teamModel{
 		apiURL: apiURL,
-		apiKey: apiKey,
 		scope:  scope,
 		client: client,
 		state:  teamPaneLoading,
@@ -105,11 +103,11 @@ func (m *teamModel) fetchActiveDetailsCmd(teamID string) tea.Cmd {
 	if teamID == "" {
 		return func() tea.Msg { return teamAccessMsg{TeamID: "", Found: true} }
 	}
-	apiURL, apiKey := m.apiURL, m.apiKey
+	apiURL := m.apiURL
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		cfg := teams.Config{APIURL: apiURL, APIKey: apiKey, Team: teamID}
+		cfg := teams.Config{APIURL: apiURL, Team: teamID}
 		t, err := teams.GetTeam(ctx, cfg, teamID)
 		if err != nil {
 			return teamAccessMsg{TeamID: teamID, Found: false, Err: err}
@@ -134,7 +132,7 @@ func (m *teamModel) fetchMembershipsCmd() tea.Cmd {
 		defer cancel()
 
 		ms, err := teams.ListMyMemberships(ctx, teams.Config{
-			APIURL: m.apiURL, APIKey: m.apiKey, Team: m.scope.TeamID,
+			APIURL: m.apiURL, Team: m.scope.TeamID,
 		})
 		if err != nil {
 			return teamMembershipsMsg{Err: err}

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -32,6 +32,16 @@ func Init(timeout time.Duration) {
 	httpClient = &http.Client{Timeout: timeout}
 }
 
+// SetTransport installs rt as the round-tripper for the shared client. The
+// CLI uses it to layer the auth package's reactive 401 → refresh →
+// retry-once behavior on top of the default transport. Call after [Init],
+// which replaces the client.
+func SetTransport(rt http.RoundTripper) {
+	if httpClient != nil {
+		httpClient.Transport = rt
+	}
+}
+
 // SetUserAgent configures the User-Agent header stamped onto every
 // outbound request through [Do]. Typical value:
 // "truestamp-cli/<version> (<os>/<arch>)". Pass an empty string to

--- a/internal/items/create.go
+++ b/internal/items/create.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/truestamp/truestamp-cli/internal/auth"
 	"github.com/truestamp/truestamp-cli/internal/httpclient"
 )
 
@@ -30,14 +31,15 @@ type CreateItemResponse struct {
 }
 
 // CreateItem calls [CreateItemCtx] with [context.Background].
-func CreateItem(apiURL, apiKey, team string, claims map[string]any, visibility string, tags []string) (*CreateItemResponse, error) {
-	return CreateItemCtx(context.Background(), apiURL, apiKey, team, claims, visibility, tags)
+func CreateItem(apiURL, team string, claims map[string]any, visibility string, tags []string) (*CreateItemResponse, error) {
+	return CreateItemCtx(context.Background(), apiURL, team, claims, visibility, tags)
 }
 
 // CreateItemCtx sends a JSON:API POST request to create a new item. claims
 // is the nested claims map (hash, hash_type, name, etc.); visibility and
 // tags are top-level item attributes. ctx cancels the in-flight request.
-func CreateItemCtx(ctx context.Context, apiURL, apiKey, team string, claims map[string]any, visibility string, tags []string) (*CreateItemResponse, error) {
+// The credential is applied by the process-wide [auth.Authorizer].
+func CreateItemCtx(ctx context.Context, apiURL, team string, claims map[string]any, visibility string, tags []string) (*CreateItemResponse, error) {
 	// Build JSON:API envelope
 	attributes := map[string]any{
 		"claims": claims,
@@ -67,7 +69,9 @@ func CreateItemCtx(ctx context.Context, apiURL, apiKey, team string, claims map[
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/vnd.api+json")
-	req.Header.Set("Authorization", "Bearer "+apiKey)
+	if err := auth.AuthorizeRequest(ctx, req); err != nil {
+		return nil, err
+	}
 	if team != "" {
 		req.Header.Set("tenant", team)
 	}

--- a/internal/items/create_test.go
+++ b/internal/items/create_test.go
@@ -9,9 +9,22 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/truestamp/truestamp-cli/internal/auth"
 )
+
+// TestMain installs an api-key Authorizer for the whole package so
+// CreateItem/CreateItemCtx stamp the Authorization header. The key
+// matches the "Bearer key" header TestCreateItem_Success asserts.
+func TestMain(m *testing.M) {
+	auth.SetDefault(auth.APIKeyAuthorizer("key"))
+	code := m.Run()
+	auth.SetDefault(nil)
+	os.Exit(code)
+}
 
 // --- parseResponse ---------------------------------------------------
 
@@ -151,7 +164,7 @@ func TestCreateItem_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	r, err := CreateItem(srv.URL, "key", "team-1",
+	r, err := CreateItem(srv.URL, "team-1",
 		map[string]any{"hash": "aa", "hash_type": "sha256", "name": "x"},
 		"public", []string{"foo"})
 	if err != nil {
@@ -171,7 +184,7 @@ func TestCreateItem_NoTenantWhenEmpty(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":{"id":"x"}}`))
 	}))
 	defer srv.Close()
-	_, err := CreateItemCtx(context.Background(), srv.URL, "key", "",
+	_, err := CreateItemCtx(context.Background(), srv.URL, "",
 		map[string]any{}, "", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -184,14 +197,14 @@ func TestCreateItem_APIError(t *testing.T) {
 		_, _ = w.Write([]byte(`{"errors":[{"detail":"bad request"}]}`))
 	}))
 	defer srv.Close()
-	_, err := CreateItem(srv.URL, "key", "", map[string]any{}, "", nil)
+	_, err := CreateItem(srv.URL, "", map[string]any{}, "", nil)
 	if err == nil || !strings.Contains(err.Error(), "bad request") {
 		t.Errorf("expected API error, got %v", err)
 	}
 }
 
 func TestCreateItem_UnreachableHost(t *testing.T) {
-	_, err := CreateItem("http://127.0.0.1:1", "key", "", map[string]any{}, "", nil)
+	_, err := CreateItem("http://127.0.0.1:1", "", map[string]any{}, "", nil)
 	if err == nil {
 		t.Error("expected connection error")
 	}
@@ -202,7 +215,7 @@ func TestCreateItem_MalformedResponse(t *testing.T) {
 		_, _ = w.Write([]byte("not json"))
 	}))
 	defer srv.Close()
-	_, err := CreateItem(srv.URL, "key", "", map[string]any{}, "", nil)
+	_, err := CreateItem(srv.URL, "", map[string]any{}, "", nil)
 	if err == nil {
 		t.Error("expected parse error")
 	}
@@ -215,7 +228,7 @@ func TestCreateItem_TagsEchoedInRequest(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":{"id":"x"}}`))
 	}))
 	defer srv.Close()
-	_, err := CreateItem(srv.URL, "key", "", map[string]any{"x": 1}, "private",
+	_, err := CreateItem(srv.URL, "", map[string]any{"x": 1}, "private",
 		[]string{"a", "b"})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/proof/download.go
+++ b/internal/proof/download.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/truestamp/truestamp-cli/internal/auth"
 	"github.com/truestamp/truestamp-cli/internal/httpclient"
 	"github.com/truestamp/truestamp-cli/internal/proof/ptype"
 )
@@ -62,8 +63,8 @@ func DownloadCtx(ctx context.Context, rawURL string) ([]byte, error) {
 }
 
 // Generate calls [GenerateCtx] with [context.Background].
-func Generate(apiURL, apiKey, team, id, subjectType, format string) ([]byte, error) {
-	return GenerateCtx(context.Background(), apiURL, apiKey, team, id, subjectType, format)
+func Generate(apiURL, team, id, subjectType, format string) ([]byte, error) {
+	return GenerateCtx(context.Background(), apiURL, team, id, subjectType, format)
 }
 
 // GenerateCtx requests a proof bundle from the Truestamp API for the given
@@ -79,7 +80,8 @@ func Generate(apiURL, apiKey, team, id, subjectType, format string) ([]byte, err
 //
 // format is "json" or "cbor". Returns raw bytes ready to write to a file
 // (pretty JSON or decoded CBOR binary). ctx cancels the in-flight request.
-func GenerateCtx(ctx context.Context, apiURL, apiKey, team, id, subjectType, format string) ([]byte, error) {
+// The credential is applied by the process-wide [auth.Authorizer].
+func GenerateCtx(ctx context.Context, apiURL, team, id, subjectType, format string) ([]byte, error) {
 	dataFields := map[string]string{"id": id}
 	if format != "" && format != "json" {
 		dataFields["format"] = format
@@ -99,7 +101,9 @@ func GenerateCtx(ctx context.Context, apiURL, apiKey, team, id, subjectType, for
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/vnd.api+json")
-	req.Header.Set("Authorization", "Bearer "+apiKey)
+	if err := auth.AuthorizeRequest(ctx, req); err != nil {
+		return nil, err
+	}
 	if team != "" {
 		req.Header.Set("tenant", team)
 	}

--- a/internal/proof/extra_test.go
+++ b/internal/proof/extra_test.go
@@ -8,12 +8,24 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/fxamacker/cbor/v2"
+	"github.com/truestamp/truestamp-cli/internal/auth"
 	"github.com/truestamp/truestamp-cli/internal/proof/ptype"
 )
+
+// TestMain installs an api-key Authorizer so Generate authorizes its
+// outbound request. These tests assert no auth header, but the request
+// must still be authenticated end-to-end.
+func TestMain(m *testing.M) {
+	auth.SetDefault(auth.APIKeyAuthorizer("key"))
+	code := m.Run()
+	auth.SetDefault(nil)
+	os.Exit(code)
+}
 
 // --- id.go (DetectIDType) --------------------------------------------------
 
@@ -445,7 +457,7 @@ func TestGenerateCtx_Success(t *testing.T) {
 		_, _ = w.Write([]byte(`{"result":` + validProofJSON + `}`))
 	}))
 	defer srv.Close()
-	data, err := Generate(srv.URL, "key", "team", "01HJHB01T8FYZ7YTR9P5N62K5B", "auto", "json")
+	data, err := Generate(srv.URL, "team", "01HJHB01T8FYZ7YTR9P5N62K5B", "auto", "json")
 	if err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
@@ -461,7 +473,7 @@ func TestGenerateCtx_CBORSuccess(t *testing.T) {
 		_, _ = w.Write([]byte(`{"result":"` + encodeBase64Std(rawCBOR) + `"}`))
 	}))
 	defer srv.Close()
-	data, err := Generate(srv.URL, "k", "", "01HJHB01T8FYZ7YTR9P5N62K5B", "auto", "cbor")
+	data, err := Generate(srv.URL, "", "01HJHB01T8FYZ7YTR9P5N62K5B", "auto", "cbor")
 	if err != nil {
 		t.Fatalf("Generate(cbor): %v", err)
 	}
@@ -476,7 +488,7 @@ func TestGenerateCtx_APIError(t *testing.T) {
 		_, _ = w.Write([]byte(`{"errors":[{"detail":"bad id","title":"invalid"}]}`))
 	}))
 	defer srv.Close()
-	_, err := Generate(srv.URL, "k", "", "bad", "auto", "json")
+	_, err := Generate(srv.URL, "", "bad", "auto", "json")
 	if err == nil {
 		t.Error("expected API error")
 	}
@@ -491,7 +503,7 @@ func TestGenerateCtx_APIErrorHTMLPage(t *testing.T) {
 		_, _ = w.Write([]byte("<html>oops</html>"))
 	}))
 	defer srv.Close()
-	_, err := Generate(srv.URL, "k", "", "id", "auto", "json")
+	_, err := Generate(srv.URL, "", "id", "auto", "json")
 	if err == nil {
 		t.Error("expected error for HTML response")
 	}
@@ -506,7 +518,7 @@ func TestGenerateCtx_APIErrorTitleOnly(t *testing.T) {
 		_, _ = w.Write([]byte(`{"errors":[{"title":"Not Found"}]}`))
 	}))
 	defer srv.Close()
-	_, err := Generate(srv.URL, "k", "", "id", "auto", "json")
+	_, err := Generate(srv.URL, "", "id", "auto", "json")
 	if err == nil {
 		t.Error("expected error")
 	}
@@ -521,7 +533,7 @@ func TestGenerateCtx_APIErrorUnparseable(t *testing.T) {
 		_, _ = w.Write([]byte("upstream exploded"))
 	}))
 	defer srv.Close()
-	_, err := Generate(srv.URL, "k", "", "id", "auto", "json")
+	_, err := Generate(srv.URL, "", "id", "auto", "json")
 	if err == nil {
 		t.Error("expected error")
 	}
@@ -532,7 +544,7 @@ func TestGenerateCtx_MissingResultField(t *testing.T) {
 		_, _ = w.Write([]byte(`{"nope": 1}`))
 	}))
 	defer srv.Close()
-	_, err := Generate(srv.URL, "k", "", "id", "auto", "json")
+	_, err := Generate(srv.URL, "", "id", "auto", "json")
 	if err == nil {
 		t.Error("expected error for missing result")
 	}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -35,6 +35,19 @@ var (
 	// and others don't. Stops at the next whitespace or quote so a
 	// surrounding error message stays readable.
 	bearerRe = regexp.MustCompile(`(?i)Bearer\s+[^"\s]+`)
+
+	// oauthQueryRe matches the OAuth-flow secrets that can appear in a
+	// query string or form body echoed by an HTTP error (the access /
+	// refresh token, the PKCE verifier, an authorization code, or a
+	// client secret). Stops at the next delimiter so neighbouring params
+	// survive.
+	oauthQueryRe = regexp.MustCompile(`(?i)(access_token|refresh_token|code_verifier|client_secret|\bcode)=[^&"'\s]*`)
+
+	// oauthJSONRe matches the same secrets as JSON string values
+	// (`"refresh_token":"…"`), the shape of a token-endpoint response body
+	// that a RetrieveError may surface. `code` is intentionally excluded
+	// here — as a JSON key it is too often an innocuous error/status code.
+	oauthJSONRe = regexp.MustCompile(`(?i)("(?:access_token|refresh_token|code_verifier|client_secret)"\s*:\s*")[^"]*(")`)
 )
 
 // String applies every redaction pattern to s and returns the cleaned
@@ -47,6 +60,8 @@ func String(s string) string {
 	}
 	s = apiKeyRe.ReplaceAllString(s, "api_key="+REDACTED)
 	s = bearerRe.ReplaceAllString(s, "Bearer "+REDACTED)
+	s = oauthQueryRe.ReplaceAllString(s, "${1}="+REDACTED)
+	s = oauthJSONRe.ReplaceAllString(s, "${1}"+REDACTED+"${2}")
 	return s
 }
 
@@ -60,3 +75,21 @@ func Error(err error) string {
 	}
 	return String(err.Error())
 }
+
+// WrapError returns an error whose Error() string is redacted but which
+// still unwraps to err, so errors.Is / errors.As keep working through it.
+// Use this (instead of fmt.Errorf with %s + Error) when an error must be
+// both redacted for display AND remain classifiable by the caller — e.g.
+// a token error that has to stay errors.Is(ErrSessionExpired) for the
+// WebSocket's fatal-session detection while never leaking token bytes.
+func WrapError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return wrappedError{err: err}
+}
+
+type wrappedError struct{ err error }
+
+func (w wrappedError) Error() string { return String(w.err.Error()) }
+func (w wrappedError) Unwrap() error { return w.err }

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -101,6 +101,47 @@ func TestStringBearer(t *testing.T) {
 	}
 }
 
+func TestStringOAuth(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "access_token query param",
+			in:   `callback ?access_token=jwt.abc.def&state=x`,
+			want: `callback ?access_token=REDACTED&state=x`,
+		},
+		{
+			name: "refresh_token value redacted, grant_type label kept",
+			in:   `grant_type=refresh_token&refresh_token=rt_secret&client_id=c`,
+			want: `grant_type=refresh_token&refresh_token=REDACTED&client_id=c`,
+		},
+		{
+			name: "code_verifier and code params",
+			in:   `code_verifier=abc123&code=xyz`,
+			want: `code_verifier=REDACTED&code=REDACTED`,
+		},
+		{
+			name: "json token response body",
+			in:   `{"access_token":"jwt","refresh_token":"rt","token_type":"Bearer"}`,
+			want: `{"access_token":"REDACTED","refresh_token":"REDACTED","token_type":"Bearer"}`,
+		},
+		{
+			name: "invalid_grant error body is not over-redacted",
+			in:   `{"error":"invalid_grant"}`,
+			want: `{"error":"invalid_grant"}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := String(tc.in); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestStringBoth(t *testing.T) {
 	in := `dial wss://x?api_key=truestamp_a&vsn=2.0.0; tried Authorization: Bearer truestamp_b`
 	got := String(in)
@@ -151,6 +192,9 @@ func FuzzRedact(f *testing.F) {
 		"api_key=a&vsn=1\nAuthorization: Bearer y",
 		"api_key=\x00\x01\x02&vsn=1",
 		"api_key=" + strings.Repeat("A", 1000),
+		"access_token=jwt&refresh_token=rt&code=c&code_verifier=v",
+		`{"access_token":"x","refresh_token":"y"}`,
+		"grant_type=refresh_token&refresh_token=rt",
 	}
 	for _, s := range seeds {
 		f.Add(s)
@@ -173,6 +217,16 @@ func FuzzRedact(f *testing.F) {
 			// remaining match should equal that exactly.
 			if m != "Bearer "+REDACTED {
 				t.Fatalf("Bearer match not redacted: %q (in %q)", m, out)
+			}
+		}
+		for _, m := range oauthQueryRe.FindAllString(out, -1) {
+			if !strings.HasSuffix(m, "="+REDACTED) {
+				t.Fatalf("oauth query match not redacted: %q (in %q)", m, out)
+			}
+		}
+		for _, m := range oauthJSONRe.FindAllString(out, -1) {
+			if !strings.Contains(m, REDACTED) {
+				t.Fatalf("oauth json match not redacted: %q (in %q)", m, out)
 			}
 		}
 	})

--- a/internal/teams/client.go
+++ b/internal/teams/client.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/truestamp/truestamp-cli/internal/auth"
 	"github.com/truestamp/truestamp-cli/internal/httpclient"
 )
 
@@ -87,10 +88,11 @@ func (e *APIError) Error() string {
 func (e *APIError) Unwrap() error { return e.sentinel }
 
 // Config carries the subset of runtime configuration needed for a request.
-// Kept small to avoid importing the top-level config package.
+// Kept small to avoid importing the top-level config package. The
+// credential is supplied out-of-band by the process-wide [auth.Authorizer]
+// (set in cmd/root); only the tenant scoping lives here.
 type Config struct {
 	APIURL string // e.g. https://www.truestamp.com/api/json
-	APIKey string // Bearer token (never logged)
 	Team   string // optional tenant id; sent verbatim as the `tenant` header
 }
 
@@ -383,15 +385,17 @@ func GetMyRoleOnTeam(ctx context.Context, cfg Config, teamID string) (string, er
 // doGet issues an authenticated GET and returns the response body on 2xx.
 // On non-2xx returns an *APIError wrapping one of the class sentinels.
 func doGet(ctx context.Context, cfg Config, path string) ([]byte, error) {
-	if cfg.APIKey == "" {
-		return nil, &APIError{Status: 401, Detail: "API key not set", sentinel: ErrUnauthorized}
+	if auth.Default().Mode() == auth.ModeNone {
+		return nil, &APIError{Status: 401, Detail: "not authenticated", sentinel: ErrUnauthorized}
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.APIURL+path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Accept", "application/vnd.api+json")
-	req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
+	if err := auth.AuthorizeRequest(ctx, req); err != nil {
+		return nil, &APIError{Status: 401, Detail: err.Error(), sentinel: ErrUnauthorized}
+	}
 	if cfg.Team != "" {
 		req.Header.Set("tenant", cfg.Team)
 	}

--- a/internal/teams/client_test.go
+++ b/internal/teams/client_test.go
@@ -8,9 +8,23 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/truestamp/truestamp-cli/internal/auth"
 )
+
+// TestMain installs an api-key Authorizer for the whole package so the
+// JSON:API client authorizes outbound requests (the teams client
+// 401s when auth.Default().Mode() == auth.ModeNone). The key matches
+// the "Bearer test-key" header these tests assert.
+func TestMain(m *testing.M) {
+	auth.SetDefault(auth.APIKeyAuthorizer("test-key"))
+	code := m.Run()
+	auth.SetDefault(nil)
+	os.Exit(code)
+}
 
 const (
 	personalTeamID = "019db702-b08c-73dc-a7cd-2c5e011f1dad"
@@ -76,7 +90,7 @@ const jsonAPISingleTeamBody = `{
 func newServer(t *testing.T, fn http.HandlerFunc) (Config, func()) {
 	t.Helper()
 	srv := httptest.NewServer(fn)
-	return Config{APIURL: srv.URL, APIKey: "test-key"}, srv.Close
+	return Config{APIURL: srv.URL}, srv.Close
 }
 
 // twoEndpointMux serves both /memberships and /teams against the
@@ -109,7 +123,7 @@ func twoEndpointMux(t *testing.T, membershipsBody, teamsBody string) (Config, fu
 		_, _ = w.Write([]byte(teamsBody))
 	})
 	srv := httptest.NewServer(mux)
-	return Config{APIURL: srv.URL, APIKey: "test-key"}, srv.Close
+	return Config{APIURL: srv.URL}, srv.Close
 }
 
 func TestListMyMemberships_HappyPath(t *testing.T) {
@@ -194,7 +208,7 @@ func TestListMyMemberships_TeamsCallReturnsError(t *testing.T) {
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
-	cfg := Config{APIURL: srv.URL, APIKey: "test-key"}
+	cfg := Config{APIURL: srv.URL}
 
 	if _, err := ListMyMemberships(context.Background(), cfg); err == nil {
 		t.Fatal("expected error when /teams 500s")
@@ -215,7 +229,7 @@ func TestListMyMemberships_MembershipsCallSoftFails(t *testing.T) {
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
-	cfg := Config{APIURL: srv.URL, APIKey: "test-key"}
+	cfg := Config{APIURL: srv.URL}
 
 	got, err := ListMyMemberships(context.Background(), cfg)
 	if err != nil {
@@ -264,7 +278,7 @@ func TestListMyMemberships_PaginationWalksMultiplePages(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 	_ = page
-	cfg := Config{APIURL: srv.URL, APIKey: "test-key"}
+	cfg := Config{APIURL: srv.URL}
 
 	got, err := ListMyMemberships(context.Background(), cfg)
 	if err != nil {
@@ -313,7 +327,7 @@ func TestListMyMemberships_TenantHeaderForwarded(t *testing.T) {
 	mux.HandleFunc("/teams", check("teams"))
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
-	cfg := Config{APIURL: srv.URL, APIKey: "test-key", Team: personalTeamID}
+	cfg := Config{APIURL: srv.URL, Team: personalTeamID}
 
 	if _, err := ListMyMemberships(context.Background(), cfg); err != nil {
 		t.Fatalf("ListMyMemberships: %v", err)
@@ -354,14 +368,19 @@ func TestGetTeam_EmptyIDRejectedClientSide(t *testing.T) {
 
 func TestDoGet_NoAPIKeyShortCircuit(t *testing.T) {
 	cfg, stop := newServer(t, func(_ http.ResponseWriter, _ *http.Request) {
-		t.Fatal("server should not be called when api key is empty")
+		t.Fatal("server should not be called when no credential is configured")
 	})
 	defer stop()
-	cfg.APIKey = ""
+
+	// With no Authorizer (ModeNone), the client must short-circuit
+	// with ErrUnauthorized before touching the network. Restore the
+	// package-wide api-key authorizer afterward.
+	auth.SetDefault(nil)
+	t.Cleanup(func() { auth.SetDefault(auth.APIKeyAuthorizer("test-key")) })
 
 	_, err := ListMyMemberships(context.Background(), cfg)
 	if err == nil {
-		t.Fatal("expected error for empty api key")
+		t.Fatal("expected error when no credential is configured")
 	}
 	if !errors.Is(err, ErrUnauthorized) {
 		t.Errorf("err should wrap ErrUnauthorized, got %v", err)

--- a/internal/verify/remote.go
+++ b/internal/verify/remote.go
@@ -5,6 +5,7 @@ package verify
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,6 +13,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/truestamp/truestamp-cli/internal/auth"
 	"github.com/truestamp/truestamp-cli/internal/bitcoin"
 	"github.com/truestamp/truestamp-cli/internal/httpclient"
 	"github.com/truestamp/truestamp-cli/internal/proof"
@@ -19,10 +21,11 @@ import (
 	"github.com/truestamp/truestamp-cli/internal/tscrypto"
 )
 
-// RemoteOptions holds configuration for remote verification.
+// RemoteOptions holds configuration for remote verification. The
+// credential is applied by the process-wide [auth.Authorizer]; only the
+// tenant scoping is carried here.
 type RemoteOptions struct {
 	APIURL       string
-	APIKey       string
 	Team         string // team ID, sent as tenant header
 	ExpectedHash string // hex hash to compare against claims.hash
 
@@ -64,9 +67,15 @@ type apiError struct {
 	Detail string `json:"detail"`
 }
 
-// RunRemote sends the proof to the Truestamp API for server-side verification
-// and returns a Report compatible with the local verification output.
+// RunRemote calls [RunRemoteCtx] with [context.Background].
 func RunRemote(filename string, opts RemoteOptions) (*Report, error) {
+	return RunRemoteCtx(context.Background(), filename, opts)
+}
+
+// RunRemoteCtx sends the proof to the Truestamp API for server-side
+// verification and returns a Report compatible with the local verification
+// output. ctx cancels the in-flight request and bounds any token refresh.
+func RunRemoteCtx(ctx context.Context, filename string, opts RemoteOptions) (*Report, error) {
 	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("reading proof file: %w", err)
@@ -117,12 +126,14 @@ func RunRemote(filename string, opts RemoteOptions) (*Report, error) {
 
 	// POST to the API
 	url := opts.APIURL + endpoint
-	req, err := http.NewRequest("POST", url, bytes.NewReader(bodyBytes))
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(bodyBytes))
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/vnd.api+json")
-	req.Header.Set("Authorization", "Bearer "+opts.APIKey)
+	if err := auth.AuthorizeRequest(ctx, req); err != nil {
+		return nil, err
+	}
 	if opts.Team != "" {
 		req.Header.Set("tenant", opts.Team)
 	}

--- a/internal/verify/remote_test.go
+++ b/internal/verify/remote_test.go
@@ -10,7 +10,21 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/truestamp/truestamp-cli/internal/auth"
 )
+
+// TestMain installs an api-key Authorizer for the whole package so
+// RunRemote stamps the Authorization header. The key matches the
+// "Bearer test-key" header TestRunRemote_Success asserts; tests that
+// pass other key strings to RemoteOptions no longer carry a credential
+// of their own (the field was removed) and rely on this default.
+func TestMain(m *testing.M) {
+	auth.SetDefault(auth.APIKeyAuthorizer("test-key"))
+	code := m.Run()
+	auth.SetDefault(nil)
+	os.Exit(code)
+}
 
 // makeProofFile writes a minimal valid compact-format JSON proof to a temp file.
 func makeProofFile(t *testing.T) string {
@@ -86,7 +100,6 @@ func TestRunRemote_Success(t *testing.T) {
 
 	report, err := RunRemote(proofFile, RemoteOptions{
 		APIURL: server.URL,
-		APIKey: "test-key",
 		Team:   "team-123",
 	})
 	if err != nil {
@@ -139,7 +152,6 @@ func TestRunRemote_VerificationFailed(t *testing.T) {
 
 	report, err := RunRemote(makeProofFile(t), RemoteOptions{
 		APIURL: server.URL,
-		APIKey: "test-key",
 	})
 	if err != nil {
 		t.Fatalf("RunRemote error: %v", err)
@@ -166,7 +178,6 @@ func TestRunRemote_NoTenantHeader_WhenTeamEmpty(t *testing.T) {
 
 	_, err := RunRemote(makeProofFile(t), RemoteOptions{
 		APIURL: server.URL,
-		APIKey: "test-key",
 		Team:   "",
 	})
 	if err != nil {
@@ -183,7 +194,6 @@ func TestRunRemote_APIError401(t *testing.T) {
 
 	_, err := RunRemote(makeProofFile(t), RemoteOptions{
 		APIURL: server.URL,
-		APIKey: "bad-key",
 	})
 	if err == nil {
 		t.Fatal("expected error for 401")
@@ -202,7 +212,6 @@ func TestRunRemote_APIError400(t *testing.T) {
 
 	_, err := RunRemote(makeProofFile(t), RemoteOptions{
 		APIURL: server.URL,
-		APIKey: "test-key",
 	})
 	if err == nil {
 		t.Fatal("expected error for 400")
@@ -212,7 +221,6 @@ func TestRunRemote_APIError400(t *testing.T) {
 func TestRunRemote_MissingFile(t *testing.T) {
 	_, err := RunRemote("/nonexistent/proof.json", RemoteOptions{
 		APIURL: "http://localhost",
-		APIKey: "test-key",
 	})
 	if err == nil {
 		t.Fatal("expected error for missing file")
@@ -225,7 +233,6 @@ func TestRunRemote_InvalidJSON(t *testing.T) {
 
 	_, err := RunRemote(path, RemoteOptions{
 		APIURL: "http://localhost",
-		APIKey: "test-key",
 	})
 	if err == nil {
 		t.Fatal("expected error for invalid JSON")
@@ -308,7 +315,6 @@ func TestRunRemote_ItemProof_SubjectType(t *testing.T) {
 
 	report, err := RunRemote(makeProofFile(t), RemoteOptions{
 		APIURL: server.URL,
-		APIKey: "test-key",
 	})
 	if err != nil {
 		t.Fatalf("RunRemote error: %v", err)
@@ -338,7 +344,6 @@ func TestRunRemote_EntropyProof_SubjectType(t *testing.T) {
 
 	report, err := RunRemote(makeEntropyProofFile(t), RemoteOptions{
 		APIURL: server.URL,
-		APIKey: "test-key",
 	})
 	if err != nil {
 		t.Fatalf("RunRemote error: %v", err)
@@ -430,7 +435,7 @@ func TestRunRemote_CBORInput(t *testing.T) {
 	}))
 	defer server.Close()
 
-	_, err = RunRemote(cborPath, RemoteOptions{APIURL: server.URL, APIKey: "k"})
+	_, err = RunRemote(cborPath, RemoteOptions{APIURL: server.URL})
 	if err != nil {
 		t.Fatalf("RunRemote(cbor): %v", err)
 	}
@@ -442,7 +447,7 @@ func TestRunRemote_MalformedJSONResponse(t *testing.T) {
 		_, _ = w.Write([]byte("not json"))
 	}))
 	defer server.Close()
-	_, err := RunRemote(makeProofFile(t), RemoteOptions{APIURL: server.URL, APIKey: "k"})
+	_, err := RunRemote(makeProofFile(t), RemoteOptions{APIURL: server.URL})
 	if err == nil {
 		t.Fatal("expected parse error for non-JSON response")
 	}
@@ -453,7 +458,7 @@ func TestRunRemote_EmptyResultField(t *testing.T) {
 		_, _ = w.Write([]byte(`{"errors":[]}`))
 	}))
 	defer server.Close()
-	_, err := RunRemote(makeProofFile(t), RemoteOptions{APIURL: server.URL, APIKey: "k"})
+	_, err := RunRemote(makeProofFile(t), RemoteOptions{APIURL: server.URL})
 	if err == nil || !contains(err.Error(), "result") {
 		t.Errorf("expected result-missing error, got %v", err)
 	}
@@ -462,7 +467,6 @@ func TestRunRemote_EmptyResultField(t *testing.T) {
 func TestRunRemote_UnreachableHost(t *testing.T) {
 	_, err := RunRemote(makeProofFile(t), RemoteOptions{
 		APIURL: "http://127.0.0.1:1",
-		APIKey: "k",
 	})
 	if err == nil {
 		t.Fatal("expected connection error")
@@ -486,7 +490,6 @@ func TestRunRemote_ExpectedHashIncluded(t *testing.T) {
 
 	_, err := RunRemote(makeProofFile(t), RemoteOptions{
 		APIURL:       server.URL,
-		APIKey:       "k",
 		ExpectedHash: "deadbeef",
 	})
 	if err != nil {

--- a/internal/wschannel/client.go
+++ b/internal/wschannel/client.go
@@ -92,6 +92,23 @@ const ReconnectedEvent = "rejoined"
 // not associated with any channel topic).
 const ReconnectingEvent = "reconnecting"
 
+// TokenRefreshEvent is a synthetic event emitted when the server signals
+// OAuth access-token expiry (its `token_expired` push). The client is
+// re-dialling with a refreshed token; applications can show a transient
+// "refreshing session" hint. Topic is empty.
+const TokenRefreshEvent = "token_refreshing"
+
+// AuthFailedEvent is emitted when reconnection cannot proceed because the
+// OAuth session is permanently dead (refresh token expired/revoked/reused).
+// The client stops retrying; the user must re-authenticate. Payload carries
+// a redacted `reason`. Topic is empty.
+const AuthFailedEvent = "auth_failed"
+
+// tokenRefreshCommand is the channel command the client pushes to refresh its
+// OAuth access token IN-BAND (the proactive keep-alive) without reconnecting.
+// The server re-validates the new token and reschedules its expiry timer.
+const tokenRefreshCommand = "token.refresh"
+
 // Client is a Phoenix Channel session multiplexing one or more topics
 // over a single WebSocket. It maintains the connection, a heartbeat,
 // ref → reply correlation, and a fan-out of server pushes from every
@@ -115,6 +132,10 @@ const ReconnectingEvent = "reconnecting"
 type Client struct {
 	url               string
 	apiKey            string
+	bearerToken       func(context.Context) (string, error)
+	fatalDialErr      func(error) bool
+	forceRefresh      func(context.Context) error
+	accessTokenExpiry func() time.Time
 	primaryTopic      string
 	heartbeatInterval time.Duration
 	log               *slog.Logger
@@ -173,6 +194,12 @@ type Client struct {
 	//   StatusReconnecting — firstConnectDone == true, session gate closed
 	connectStarted   atomic.Bool
 	firstConnectDone atomic.Bool
+	// authDead is set when the OAuth session is permanently dead (a
+	// forced refresh on token_expired returned a fatal error). The session
+	// loop checks it and stops reconnecting instead of re-dialing with a
+	// locally-still-"valid" but server-rejected access token (the
+	// clock-skew loop).
+	authDead atomic.Bool
 
 	// runCtx scopes goroutine-internal I/O to the client's lifetime;
 	// cancelled on Close so reads/writes/heartbeats abort cleanly.
@@ -192,8 +219,38 @@ type Options struct {
 	URL string
 
 	// APIKey is the Truestamp API key. Sent as a query parameter to the
-	// Socket.connect/3 callback on the server.
+	// Socket.connect/3 callback on the server. Mutually exclusive with
+	// BearerToken; when BearerToken is set it takes precedence.
 	APIKey string
+
+	// BearerToken, when set, switches the client to OAuth mode: a fresh
+	// access token is fetched on every (re)dial and sent as the
+	// `access_token` query param on the WebSocket upgrade. (A Phoenix
+	// upgrade can't expose the Authorization header to the socket's
+	// connect/3, so the token rides the query like the api_key does.)
+	// Pulling the token per-dial means a reconnect after a token_expired
+	// automatically carries a refreshed credential.
+	BearerToken func(context.Context) (string, error)
+
+	// FatalDialErr classifies a dial error as permanently fatal (e.g. a
+	// dead OAuth session). When it returns true the session loop stops
+	// retrying and emits AuthFailedEvent instead of looping forever.
+	// Nil means "no dial error is fatal" (always retry).
+	FatalDialErr func(error) bool
+
+	// ForceRefresh, when set, is invoked on a server `token_expired` push
+	// to obtain a brand-new access token *before* the reconnect re-dials —
+	// so the new socket never reuses the just-rejected token (which would
+	// otherwise loop when local/server clocks disagree). Nil disables it.
+	ForceRefresh func(context.Context) error
+
+	// AccessTokenExpiry, when set alongside BearerToken+ForceRefresh,
+	// enables the proactive in-band keep-alive: a background loop refreshes
+	// the access token and pushes `token.refresh` over the live socket
+	// shortly before this expiry, so a long session never hits the server's
+	// token_expired disconnect. Returns the zero time when unknown. Nil
+	// disables the keep-alive (the reactive token_expired path still works).
+	AccessTokenExpiry func() time.Time
 
 	// Topic is the primary channel topic Connect joins. Defaults to
 	// "console:lobby" when empty. Additional topics can be joined later
@@ -220,8 +277,8 @@ func New(opts Options) (*Client, error) {
 	if opts.URL == "" {
 		return nil, errors.New("wschannel: URL is required")
 	}
-	if opts.APIKey == "" {
-		return nil, errors.New("wschannel: APIKey is required")
+	if opts.APIKey == "" && opts.BearerToken == nil {
+		return nil, errors.New("wschannel: APIKey or BearerToken is required")
 	}
 	topic := opts.Topic
 	if topic == "" {
@@ -243,6 +300,10 @@ func New(opts Options) (*Client, error) {
 	c := &Client{
 		url:               opts.URL,
 		apiKey:            opts.APIKey,
+		bearerToken:       opts.BearerToken,
+		fatalDialErr:      opts.FatalDialErr,
+		forceRefresh:      opts.ForceRefresh,
+		accessTokenExpiry: opts.AccessTokenExpiry,
 		primaryTopic:      topic,
 		heartbeatInterval: hb,
 		log:               logger,
@@ -294,6 +355,14 @@ func (c *Client) Connect(ctx context.Context) (json.RawMessage, error) {
 	c.wg.Add(1)
 	go c.sessionLoop()
 
+	// Proactive in-band token keep-alive (OAuth only, when the caller wired
+	// the token funcs). Refreshes before expiry over the live socket so a
+	// long session never hits the server's token_expired disconnect.
+	if c.bearerToken != nil && c.forceRefresh != nil && c.accessTokenExpiry != nil {
+		c.wg.Add(1)
+		go c.keepAliveLoop()
+	}
+
 	c.openSocketGate()
 	welcome, err := c.joinTopicOnSocket(ctx, c.primaryTopic)
 	if err != nil {
@@ -334,14 +403,35 @@ func (c *Client) dial(ctx context.Context) error {
 	}
 	q := u.Query()
 	q.Set("vsn", "2.0.0")
-	q.Set("api_key", c.apiKey)
+
+	if c.bearerToken != nil {
+		// OAuth mode: pass the access token as the `access_token` query
+		// param. A Phoenix WS upgrade can't expose the Authorization header
+		// to Socket.connect/3 (Phoenix's `:x_headers` only captures `x-*`
+		// headers), so the token rides the query string exactly like
+		// `?api_key=`. Pulled fresh each dial so a reconnect after
+		// token_expired carries a refreshed credential; a token error (e.g.
+		// dead session) propagates to the session loop, which may classify
+		// it fatal via FatalDialErr. Redaction covers `access_token=` in any
+		// logged URL/error.
+		tok, terr := c.bearerToken(ctx)
+		if terr != nil {
+			// Keep the error chain intact so FatalDialErr can still classify
+			// a dead session; the message is redacted.
+			return redact.WrapError(terr)
+		}
+		q.Set("access_token", tok)
+	} else {
+		// API-key mode: query param, as Socket.connect/3 expects.
+		q.Set("api_key", c.apiKey)
+	}
 	u.RawQuery = q.Encode()
 
 	conn, _, err := websocket.Dial(ctx, u.String(), nil)
 	if err != nil {
-		// The library's error embeds the upgrade URL — including our
-		// api_key — verbatim. Redact eagerly so the cleartext token
-		// can't reach an upstream caller's UI or logger.
+		// The library's error embeds the upgrade URL — which includes our
+		// api_key or access_token — verbatim. Redact eagerly so the
+		// cleartext credential can't reach an upstream caller's UI or logger.
 		return fmt.Errorf("dial: %s", redact.Error(err))
 	}
 	conn.SetReadLimit(1 << 20)
@@ -433,6 +523,12 @@ func (c *Client) sessionLoop() {
 			// Disconnected — fall through to reconnect.
 		}
 
+		// A permanently-dead OAuth session must not be retried — the
+		// reconnect would re-present a token the server already rejected.
+		if c.authDead.Load() {
+			return
+		}
+
 		c.resetGates()
 
 		attempt := 0
@@ -454,6 +550,14 @@ func (c *Client) sessionLoop() {
 			err := c.dial(dialCtx)
 			cancel()
 			if err != nil {
+				if c.fatalDialErr != nil && c.fatalDialErr(err) {
+					// Dead OAuth session — retrying can't help. Surface
+					// it and stop the reconnect loop; the UI prompts the
+					// user to re-authenticate.
+					c.logErr(slog.LevelWarn, "fatal auth error; stopping reconnect", err)
+					c.emitAuthFailed(err)
+					return
+				}
 				c.logErr(slog.LevelInfo, "reconnect dial failed", err, "attempt", attempt)
 				continue
 			}
@@ -539,6 +643,27 @@ func (c *Client) dropConn(code websocket.StatusCode, reason string) {
 	// dropConn calls during the same outage into a single reconnect.
 	select {
 	case c.disconnect <- struct{}{}:
+	default:
+	}
+}
+
+// emitTokenRefreshing surfaces a transient "refreshing session" hint when
+// the server signals OAuth token expiry. Best-effort; dropped if the push
+// buffer is full (the subsequent reconnect events still inform the UI).
+func (c *Client) emitTokenRefreshing(payload json.RawMessage) {
+	select {
+	case c.pushes <- Push{Event: TokenRefreshEvent, Payload: payload}:
+	default:
+	}
+}
+
+// emitAuthFailed surfaces a terminal auth failure (dead OAuth session) so
+// the UI can prompt re-login. The reason is redacted before it leaves the
+// client.
+func (c *Client) emitAuthFailed(err error) {
+	payload, _ := json.Marshal(map[string]string{"reason": redact.String(err.Error())})
+	select {
+	case c.pushes <- Push{Event: AuthFailedEvent, Payload: payload}:
 	default:
 	}
 }
@@ -812,6 +937,39 @@ func (c *Client) readLoop() {
 			}
 		}
 
+		// OAuth access-token expiry. The server pushes token_expired on
+		// the joined topic, then stops that channel. Because the token is
+		// validated at *connect* (not at channel join), a re-join alone
+		// won't re-authenticate — we must re-dial the whole socket with a
+		// fresh token. Surface a "refreshing" hint, then drop the conn to
+		// trigger the reconnect path, whose dial pulls a refreshed token.
+		if f.Event == "token_expired" {
+			c.emitTokenRefreshing(f.Payload)
+			// Force a token refresh now so the upcoming reconnect dials
+			// with a genuinely new access token instead of re-presenting
+			// the just-rejected one (which would loop under clock skew).
+			// A dead session surfaces on the reconnect dial via FatalDialErr.
+			if c.forceRefresh != nil {
+				rctx, cancel := context.WithTimeout(c.runCtx, 30*time.Second)
+				rerr := c.forceRefresh(rctx)
+				cancel()
+				if rerr != nil {
+					if c.fatalDialErr != nil && c.fatalDialErr(rerr) {
+						// Dead session: stop now rather than letting the
+						// reconnect re-present a locally-"valid" but
+						// server-rejected token in a tight loop.
+						c.authDead.Store(true)
+						c.emitAuthFailed(rerr)
+					} else {
+						c.logErr(slog.LevelInfo, "token refresh on expiry failed (reconnect will retry)", rerr)
+					}
+				}
+			}
+			c.dropConn(websocket.StatusNormalClosure, "oauth token expired")
+			c.drainPending()
+			continue
+		}
+
 		// Ignore phx_close / phx_error here for V1 — the read error
 		// path will handle disconnects.
 		if f.Event == "phx_close" || f.Event == "phx_error" {
@@ -851,6 +1009,110 @@ func (c *Client) heartbeatLoop(interval time.Duration) {
 			cancel()
 		}
 	}
+}
+
+// keepAliveLoop proactively refreshes the OAuth access token IN-BAND over the
+// live socket shortly before it expires, so a long console session never hits
+// the server's token_expired disconnect. It pushes a `token.refresh` command
+// (the server re-validates the new token and reschedules its expiry timer)
+// instead of reconnecting. On any failure it does nothing and lets the
+// reactive token_expired/reconnect path take over. Polling (rather than a
+// per-token timer) keeps it trivially correct across reconnects, where the
+// token and its expiry change underneath us.
+func (c *Client) keepAliveLoop() {
+	defer c.wg.Done()
+	const (
+		poll = 15 * time.Second
+		lead = 60 * time.Second
+	)
+	t := time.NewTicker(poll)
+	defer t.Stop()
+	for {
+		select {
+		case <-c.done:
+			return
+		case <-c.runCtx.Done():
+			return
+		case <-t.C:
+			if c.authDead.Load() || !c.sessionReadyNow() {
+				continue
+			}
+			if !keepAliveDue(c.accessTokenExpiry(), time.Now(), lead) {
+				continue
+			}
+			c.inBandRefresh()
+		}
+	}
+}
+
+// keepAliveDue reports whether a proactive in-band refresh should fire: the
+// access token has a known expiry within lead of now.
+func keepAliveDue(exp, now time.Time, lead time.Duration) bool {
+	return !exp.IsZero() && exp.Sub(now) <= lead
+}
+
+// sessionReadyNow non-blockingly reports whether the session is fully
+// established (socket live AND all topics joined).
+func (c *Client) sessionReadyNow() bool {
+	select {
+	case <-c.sessionGate():
+		return true
+	default:
+		return false
+	}
+}
+
+// inBandRefresh mints a fresh access token and pushes it to the server over
+// the live socket. On success the server keeps the connection alive and
+// reschedules its expiry timer (no reconnect, no re-join). On any failure it
+// falls back to the reactive path: a dead session stops reconnect, a rejected
+// token forces a reconnect (which re-validates at connect with the fresh
+// token), and a transient delivery failure leaves the server's existing timer
+// to fire token_expired.
+func (c *Client) inBandRefresh() {
+	ctx, cancel := context.WithTimeout(c.runCtx, 30*time.Second)
+	defer cancel()
+
+	c.log.Info("oauth access token near expiry; refreshing in-band")
+
+	if err := c.forceRefresh(ctx); err != nil {
+		if c.fatalDialErr != nil && c.fatalDialErr(err) {
+			c.authDead.Store(true)
+			c.emitAuthFailed(err)
+			c.dropConn(websocket.StatusNormalClosure, "oauth session expired")
+			return
+		}
+		// Transient: leave the server's timer to fire token_expired, which
+		// the reconnect path handles.
+		c.logErr(slog.LevelWarn, "in-band refresh: token refresh failed (token_expired will recover)", err)
+		return
+	}
+
+	tok, err := c.bearerToken(ctx)
+	if err != nil {
+		c.logErr(slog.LevelWarn, "in-band refresh: could not read refreshed token", err)
+		return
+	}
+
+	reply, err := c.Push(ctx, c.primaryTopic, tokenRefreshCommand, map[string]string{"access_token": tok})
+	if err != nil {
+		// Couldn't deliver (socket hiccup) — the reconnect / token_expired
+		// path re-establishes with the already-refreshed token.
+		c.logErr(slog.LevelWarn, "in-band refresh: token.refresh push failed (reconnect will recover)", err)
+		return
+	}
+	if reply.Status != "ok" {
+		var perr struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		}
+		_ = json.Unmarshal(reply.Response, &perr)
+		c.logErr(slog.LevelInfo, "in-band token.refresh rejected; reconnecting",
+			fmt.Errorf("%s: %s", perr.Code, perr.Message))
+		c.dropConn(websocket.StatusNormalClosure, "in-band token refresh rejected")
+		return
+	}
+	c.log.Info("oauth token refreshed in-band; console session kept alive")
 }
 
 func (c *Client) allocRef() string {

--- a/internal/wschannel/keepalive_test.go
+++ b/internal/wschannel/keepalive_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2019-2026 Truestamp, Inc.
+// SPDX-License-Identifier: MIT
+
+package wschannel
+
+import (
+	"testing"
+	"time"
+)
+
+func TestKeepAliveDue(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	lead := 60 * time.Second
+	cases := []struct {
+		name string
+		exp  time.Time
+		want bool
+	}{
+		{"zero expiry (unknown) is not due", time.Time{}, false},
+		{"far future is not due", now.Add(10 * time.Minute), false},
+		{"just past the lead window is not due", now.Add(61 * time.Second), false},
+		{"within the lead window is due", now.Add(30 * time.Second), true},
+		{"exactly at the lead boundary is due", now.Add(60 * time.Second), true},
+		{"already expired is due", now.Add(-time.Minute), true},
+	}
+	for _, c := range cases {
+		if got := keepAliveDue(c.exp, now, lead); got != c.want {
+			t.Errorf("%s: keepAliveDue=%v want %v", c.name, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Make authentication OAuth2-first, with the long-lived API key retained as the CI/headless fallback. See `CHANGELOG.md` (`[Unreleased]`) for full notes.

## Highlights
- New `internal/auth` package: browser loopback Authorization Code + PKCE (S256), OS-keychain token store (0600-file fallback), rotating single-use refresh, reactive 401 → refresh → retry-once transport, precedence resolver, revoke-on-logout.
- One process-wide `Authorizer` routes the 6 HTTP call sites (`auth`, `team`, `beacon`, `create`, `download`, `verify --remote`) and the `console` WebSocket.
- Console WS auth via `?access_token=` with an in-band `token.refresh` keep-alive (zero reconnect) plus reactive `token_expired` recovery and a dead-session stop.
- `auth login` is browser-default (`--api-key` keeps the paste path); `auth logout` revokes; `auth status` / `config show` are mode-aware. Redaction extended to OAuth secrets. Deps: `golang.org/x/oauth2`, `zalando/go-keyring`, `cli/browser`.

## ⚠️ Do not cut a release from this until the truestamp-v2 server side is deployed
The OAuth flow depends on server changes (the seeded UUIDv7 `client_id`, the `?access_token=` console-socket auth, and the `token.refresh` keep-alive handler) that are currently **dev-only and uncommitted** in `truestamp-v2`. Until they ship to staging/prod, the CLI's OAuth works against localhost dev but returns `invalid_client` / WS failures elsewhere. Merging this is fine — there is no user impact without a release tag — but **hold the tag for the lockstep server deploy**.

## Verification
- Two adversarial review passes (security / functionality / UX) to unanimous sign-off; every finding fixed and regression-tested.
- Live end-to-end on localhost dev: browser login + consent, HTTP read/write, console WS connect, true zero-reconnect in-band keep-alive, and reactive recovery.
- `task precommit` green; full `task fuzz-deep` clean across 74 targets (incl. new `FuzzDiscoveryValidate` / `FuzzSessionDecode`).